### PR TITLE
Incorrect label for the "New" button on the toolbar when several item…

### DIFF
--- a/modules/app-users/src/main/resources/assets/js/app/browse/UserBrowsePanel.ts
+++ b/modules/app-users/src/main/resources/assets/js/app/browse/UserBrowsePanel.ts
@@ -43,14 +43,12 @@ export class UserBrowsePanel extends api.app.browse.BrowsePanel<UserTreeGridItem
         });
 
         const changeSelectionStatus = api.util.AppHelper.debounce((selection: TreeNode<UserTreeGridItem>[]) => {
-            const noSelection = selection.length === 0;
+            const singleSelection = selection.length === 1;
             const newAction = this.treeGrid.getTreeGridActions().NEW;
 
             let label;
 
-            if (noSelection || selection[0].getData().getType() === UserTreeGridItemType.USER_STORE) {
-                label = `${i18n('action.new')}…`;
-            } else {
+            if (singleSelection && selection[0].getData().getType() !== UserTreeGridItemType.USER_STORE) {
                 const userItem = selection[0].getData();
                 let type;
 
@@ -73,6 +71,8 @@ export class UserBrowsePanel extends api.app.browse.BrowsePanel<UserTreeGridItem
                 }
 
                 label = [i18n('action.new'), type].join(' ');
+            } else {
+                label = `${i18n('action.new')}…`;
             }
             newAction.setLabel(label);
         }, 10);

--- a/modules/app-users/src/main/resources/assets/js/app/browse/action/NewPrincipalAction.ts
+++ b/modules/app-users/src/main/resources/assets/js/app/browse/action/NewPrincipalAction.ts
@@ -14,7 +14,7 @@ export class NewPrincipalAction extends Action {
         this.setEnabled(false);
         this.onExecuted(() => {
             const principals: UserTreeGridItem[] = grid.getSelectedDataList();
-            if (principals.length > 0 && principals[0].getType() !== UserTreeGridItemType.USER_STORE) {
+            if (principals.length === 1 && principals[0].getType() !== UserTreeGridItemType.USER_STORE) {
                 new NewPrincipalEvent(principals).fire();
             } else {
                 new ShowNewPrincipalDialogEvent(principals).fire();

--- a/modules/app-users/src/main/resources/assets/js/app/create/NewPrincipalDialog.ts
+++ b/modules/app-users/src/main/resources/assets/js/app/create/NewPrincipalDialog.ts
@@ -55,7 +55,7 @@ export class NewPrincipalDialog extends api.ui.dialog.ModalDialog {
     }
 
     setSelection(selection: UserTreeGridItem[]): NewPrincipalDialog {
-        const isUserStore = selection.length > 0 && selection[0].getType() === UserTreeGridItemType.USER_STORE;
+        const isUserStore = selection.length === 1 && selection[0].getType() === UserTreeGridItemType.USER_STORE;
         if (isUserStore) {
             this.grid.setUserStore(selection[0].getUserStore());
             this.setPath(selection[0].getItemDisplayName());


### PR DESCRIPTION
…s are selected #3

Updated selection checks: multiple selections will open `New...` dialog, like the one when nothing is selected.