### PR TITLE
The UI for the about dialog looks bad in IE11 #123

### DIFF
--- a/modules/app-main/src/main/resources/assets/styles/home.less
+++ b/modules/app-main/src/main/resources/assets/styles/home.less
@@ -84,7 +84,6 @@
     margin: 0 18px 50px -15px;
 
     img {
-      height: 135px;
       margin: 12px 10px 10px 10px;
     }
   }
@@ -391,4 +390,20 @@
 
 .notification-container {
   z-index: 2500;
+}
+
+body {
+  &._0-240, &._240-360, &._360-540, &._540-720 {
+    .xp-about-dialog {
+      .cancel-button-top {
+
+        background-color: rgba(0, 0, 0, 0.8);
+
+        &:before, &:after {
+          background-color: #fff;
+        }
+
+      }
+    }
+  }
 }


### PR DESCRIPTION
-removed height styling for img tag (ie issue only)
-Adjusted close button styling so it looks good on smaller viewports (all browsers)