### PR TITLE
Remove BrowseItem usage #84

### DIFF
--- a/modules/app-applications/src/main/resources/assets/js/app/browse/ApplicationBrowseActions.ts
+++ b/modules/app-applications/src/main/resources/assets/js/app/browse/ApplicationBrowseActions.ts
@@ -4,7 +4,6 @@ import {StartApplicationAction} from './StartApplicationAction';
 import {StopApplicationAction} from './StopApplicationAction';
 import {InstallApplicationAction} from './InstallApplicationAction';
 import {UninstallApplicationAction} from './UninstallApplicationAction';
-
 import BrowseItem = api.app.browse.BrowseItem;
 import Application = api.application.Application;
 import TreeGridActions = api.ui.treegrid.actions.TreeGridActions;
@@ -45,31 +44,30 @@ export class ApplicationBrowseActions implements TreeGridActions<Application> {
         return this.allActions;
     }
 
-    updateActionsEnabledState(applicationBrowseItems: BrowseItem<Application>[]): wemQ.Promise<BrowseItem<Application>[]> {
-        let applicationsSelected = applicationBrowseItems.length;
-        let anySelected = applicationsSelected > 0;
-        let anyStarted = false;
-        let anyStopped = false;
-        let localAppSelected = false;
-        applicationBrowseItems.forEach((applicationBrowseItem: BrowseItem<Application>) => {
-            let state = applicationBrowseItem.getModel().getState();
-            if (state === Application.STATE_STARTED) {
-                anyStarted = true;
-            } else if (state === Application.STATE_STOPPED) {
-                anyStopped = true;
-            }
-            if ((<Application>applicationBrowseItem.getModel()).isLocal()) {
-                localAppSelected = true;
-            }
+    updateActionsEnabledState(browseItems: BrowseItem<Application>[]): wemQ.Promise<void> {
+        return wemQ().then(() => {
+            const applicationsSelected = browseItems.length;
+            const anySelected = applicationsSelected > 0;
+
+            let anyStarted = false;
+            let anyStopped = false;
+            let localAppSelected = false;
+
+            browseItems.forEach((browseItem: BrowseItem<Application>) => {
+                let state = browseItem.getModel().getState();
+                if (state === Application.STATE_STARTED) {
+                    anyStarted = true;
+                } else if (state === Application.STATE_STOPPED) {
+                    anyStopped = true;
+                }
+                if ((<Application>browseItem.getModel()).isLocal()) {
+                    localAppSelected = true;
+                }
+            });
+
+            this.START_APPLICATION.setEnabled(anyStopped);
+            this.STOP_APPLICATION.setEnabled(anyStarted);
+            this.UNINSTALL_APPLICATION.setEnabled(anySelected && !localAppSelected);
         });
-
-        this.START_APPLICATION.setEnabled(anyStopped);
-        this.STOP_APPLICATION.setEnabled(anyStarted);
-        this.UNINSTALL_APPLICATION.setEnabled(anySelected && !localAppSelected);
-
-        let deferred = wemQ.defer<BrowseItem<Application>[]>();
-        deferred.resolve(applicationBrowseItems);
-        return deferred.promise;
     }
-
 }

--- a/modules/app-applications/src/main/resources/assets/js/app/browse/ApplicationBrowseActions.ts
+++ b/modules/app-applications/src/main/resources/assets/js/app/browse/ApplicationBrowseActions.ts
@@ -7,6 +7,7 @@ import {UninstallApplicationAction} from './UninstallApplicationAction';
 import BrowseItem = api.app.browse.BrowseItem;
 import Application = api.application.Application;
 import TreeGridActions = api.ui.treegrid.actions.TreeGridActions;
+import BrowseItemsChanges = api.app.browse.BrowseItemsChanges;
 
 export class ApplicationBrowseActions implements TreeGridActions<Application> {
 
@@ -44,8 +45,8 @@ export class ApplicationBrowseActions implements TreeGridActions<Application> {
         return this.allActions;
     }
 
-    updateActionsEnabledState(browseItems: BrowseItem<Application>[]): wemQ.Promise<void> {
-        return wemQ().then(() => {
+    updateActionsEnabledState(browseItems: BrowseItem<Application>[], changes?: BrowseItemsChanges<any>): wemQ.Promise<void> {
+        return wemQ(true).then(() => {
             const applicationsSelected = browseItems.length;
             const anySelected = applicationsSelected > 0;
 

--- a/modules/app-applications/src/main/resources/assets/js/app/browse/ApplicationBrowseActions.ts
+++ b/modules/app-applications/src/main/resources/assets/js/app/browse/ApplicationBrowseActions.ts
@@ -45,7 +45,7 @@ export class ApplicationBrowseActions implements TreeGridActions<Application> {
         return this.allActions;
     }
 
-    updateActionsEnabledState(browseItems: BrowseItem<Application>[], changes?: BrowseItemsChanges<any>): wemQ.Promise<void> {
+    updateActionsEnabledState(browseItems: BrowseItem<Application>[], changes?: BrowseItemsChanges<Application>): wemQ.Promise<void> {
         return wemQ(true).then(() => {
             const applicationsSelected = browseItems.length;
             const anySelected = applicationsSelected > 0;

--- a/modules/app-applications/src/main/resources/assets/js/app/browse/ApplicationBrowsePanel.ts
+++ b/modules/app-applications/src/main/resources/assets/js/app/browse/ApplicationBrowsePanel.ts
@@ -41,6 +41,15 @@ export class ApplicationBrowsePanel extends api.app.browse.BrowsePanel<Applicati
         return new ApplicationBrowseItemPanel();
     }
 
+    treeNodeToBrowseItem(node: TreeNode<Application>): BrowseItem<Application>|null {
+        const data = node ? node.getData() : null;
+        return !data ? null : <BrowseItem<Application>>new BrowseItem<Application>(data)
+            .setId(data.getId())
+            .setDisplayName(data.getDisplayName())
+            .setPath(data.getName())
+            .setIconUrl(data.getIconUrl());
+    }
+
     treeNodesToBrowseItems(nodes: TreeNode<Application>[]): BrowseItem<Application>[] {
         let browseItems: BrowseItem<Application>[] = [];
 
@@ -53,12 +62,10 @@ export class ApplicationBrowsePanel extends api.app.browse.BrowsePanel<Applicati
                 }
             }
             if (i === index) {
-                let applicationEl = node.getData();
-                let item = new BrowseItem<Application>(applicationEl).setId(applicationEl.getId())
-                    .setDisplayName(applicationEl.getDisplayName())
-                    .setPath(applicationEl.getName())
-                    .setIconUrl(applicationEl.getIconUrl());
-                browseItems.push(item);
+                const item = this.treeNodeToBrowseItem(node);
+                if (item) {
+                    browseItems.push(item);
+                }
             }
         });
         return browseItems;

--- a/modules/app-contentstudio/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/app-contentstudio/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
@@ -239,7 +239,7 @@ export class ContentBrowsePanel
 
         const updateMobilePanel = (content: ContentSummaryAndCompareStatus, changed: boolean) => {
             if (changed) {
-                const item = this.toBrowseItem(content, null).toViewItem();
+                const item = this.toBrowseItem(content, null);
 
                 this.mobileContentItemStatisticsPanel.getPreviewPanel().showMask();
                 this.mobileContentItemStatisticsPanel.setItem(item);

--- a/modules/app-contentstudio/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/app-contentstudio/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
@@ -661,7 +661,7 @@ export class ContentBrowsePanel
     }
 
     private toBrowseItem(content: ContentSummaryAndCompareStatus, renderable: boolean): BrowseItem<ContentSummaryAndCompareStatus> {
-        return new BrowseItem<ContentSummaryAndCompareStatus>(content)
+        return <BrowseItem<ContentSummaryAndCompareStatus>>new BrowseItem<ContentSummaryAndCompareStatus>(content)
             .setId(content.getId())
             .setDisplayName(content.getDisplayName()).setPath(content.getPath().toString())
             .setIconUrl(new ContentIconUrlResolver().setContent(content.getContentSummary()).resolve())

--- a/modules/app-contentstudio/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/app-contentstudio/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
@@ -84,8 +84,7 @@ export class ContentBrowsePanel
             if (event.getType() === 'updated') {
                 let browseItems = this.treeNodesToBrowseItems(event.getTreeNodes());
                 this.getBrowseItemPanel().updateItems(browseItems);
-                this.getBrowseActions().updateActionsEnabledState(
-                    this.treeNodesToBrowseItems(this.treeGrid.getRoot().getFullSelection()));
+                this.getBrowseActions().updateActionsEnabledState(this.treeNodesToBrowseItems(this.treeGrid.getRoot().getFullSelection()));
             }
         });
 
@@ -290,13 +289,7 @@ export class ContentBrowsePanel
             nodes = [this.treeGrid.getFirstSelectedOrHighlightedNode()];
         }
 
-        let browseItems: BrowseItem<ContentSummaryAndCompareStatus>[] = this.treeNodesToBrowseItems(nodes);
-
-        return (browseItems.length > 0) ? browseItems[0] : null;
-    }
-
-    private isSomethingSelected(): boolean {
-        return !!this.getFirstSelectedOrHighlightedBrowseItem();
+        return this.treeNodeToBrowseItem(nodes[0]);
     }
 
     private isMobileMode(): boolean {
@@ -311,24 +304,31 @@ export class ContentBrowsePanel
         }
     }
 
+    treeNodeToBrowseItem(node: TreeNode<ContentSummaryAndCompareStatus>): ContentBrowseItem|null {
+        const data = node ? node.getData() : null;
+        return (!data || !data.getContentSummary()) ? null : <ContentBrowseItem>new ContentBrowseItem(data)
+            .setId(data.getId())
+            .setDisplayName(data.getContentSummary().getDisplayName())
+            .setPath(data.getContentSummary().getPath().toString())
+            .setIconUrl(new ContentIconUrlResolver().setContent(data.getContentSummary()).resolve());
+    }
+
     treeNodesToBrowseItems(nodes: TreeNode<ContentSummaryAndCompareStatus>[]): ContentBrowseItem[] {
         let browseItems: ContentBrowseItem[] = [];
 
         // do not proceed duplicated content. still, it can be selected
         nodes.forEach((node: TreeNode<ContentSummaryAndCompareStatus>, index: number) => {
             let i = 0;
+            // Take last in a sequence with the same id
             for (; i <= index; i++) {
                 if (nodes[i].getData().getId() === node.getData().getId()) {
                     break;
                 }
             }
             if (i === index) {
-                let data = node.getData();
-                if (!!data && !!data.getContentSummary()) {
-                    let item = new ContentBrowseItem(data).setId(data.getId()).setDisplayName(
-                        data.getContentSummary().getDisplayName()).setPath(data.getContentSummary().getPath().toString()).setIconUrl(
-                        new api.content.util.ContentIconUrlResolver().setContent(data.getContentSummary()).resolve());
-                    browseItems.push(<ContentBrowseItem> item);
+                const item = this.treeNodeToBrowseItem(node);
+                if (item) {
+                    browseItems.push(item);
                 }
             }
         });

--- a/modules/app-contentstudio/src/main/resources/assets/js/app/browse/action/ContentTreeGridActions.ts
+++ b/modules/app-contentstudio/src/main/resources/assets/js/app/browse/action/ContentTreeGridActions.ts
@@ -95,7 +95,7 @@ export class ContentTreeGridActions implements TreeGridActions<ContentSummaryAnd
     updateActionsEnabledState(browseItems: ContentBrowseItem[], changes?: BrowseItemsChanges<ContentSummaryAndCompareStatus>): wemQ.Promise<void> {
 
         if (changes && changes.getAdded().length == 0 && changes.getRemoved().length == 0) {
-            return wemQ();
+            return wemQ<void>(null);
         }
 
         this.TOGGLE_SEARCH_PANEL.setVisible(false);

--- a/modules/app-contentstudio/src/main/resources/assets/js/app/browse/action/ContentTreeGridActions.ts
+++ b/modules/app-contentstudio/src/main/resources/assets/js/app/browse/action/ContentTreeGridActions.ts
@@ -17,7 +17,6 @@ import {UndoPendingDeleteContentAction} from './UndoPendingDeleteContentAction';
 import {CreateIssueAction} from './CreateIssueAction';
 import Action = api.ui.Action;
 import TreeGridActions = api.ui.treegrid.actions.TreeGridActions;
-import BrowseItem = api.app.browse.BrowseItem;
 import BrowseItemsChanges = api.app.browse.BrowseItemsChanges;
 import ContentSummary = api.content.ContentSummary;
 import ContentSummaryAndCompareStatus = api.content.ContentSummaryAndCompareStatus;
@@ -93,24 +92,20 @@ export class ContentTreeGridActions implements TreeGridActions<ContentSummaryAnd
     }
 
     // tslint:disable-next-line:max-line-length
-    updateActionsEnabledState(contentBrowseItems: ContentBrowseItem[],
-                              changes?: BrowseItemsChanges<ContentSummaryAndCompareStatus>): wemQ.Promise<BrowseItem<ContentSummaryAndCompareStatus>[]> {
+    updateActionsEnabledState(browseItems: ContentBrowseItem[], changes?: BrowseItemsChanges<ContentSummaryAndCompareStatus>): wemQ.Promise<void> {
 
         if (changes && changes.getAdded().length == 0 && changes.getRemoved().length == 0) {
-            return wemQ(contentBrowseItems);
+            return wemQ();
         }
 
         this.TOGGLE_SEARCH_PANEL.setVisible(false);
 
         let parallelPromises: wemQ.Promise<any>[] = [
-            this.getPreviewHandler().updateState(contentBrowseItems, changes),
-            this.doUpdateActionsEnabledState(contentBrowseItems)
+            this.getPreviewHandler().updateState(browseItems, changes),
+            this.doUpdateActionsEnabledState(browseItems)
         ];
 
-        return wemQ
-            .all(parallelPromises)
-            .catch(api.DefaultErrorHandler.handle)
-            .then(() => contentBrowseItems);
+        return wemQ.all(parallelPromises).catch(api.DefaultErrorHandler.handle);
     }
 
     private resetDefaultActionsNoItemsSelected() {

--- a/modules/app-contentstudio/src/main/resources/assets/js/app/browse/action/ContentTreeGridActions.ts
+++ b/modules/app-contentstudio/src/main/resources/assets/js/app/browse/action/ContentTreeGridActions.ts
@@ -107,7 +107,10 @@ export class ContentTreeGridActions implements TreeGridActions<ContentSummaryAnd
             this.doUpdateActionsEnabledState(contentBrowseItems)
         ];
 
-        return wemQ.all(parallelPromises).then(() => wemQ(contentBrowseItems)).catch(api.DefaultErrorHandler.handle);
+        return wemQ
+            .all(parallelPromises)
+            .catch(api.DefaultErrorHandler.handle)
+            .then(() => contentBrowseItems);
     }
 
     private resetDefaultActionsNoItemsSelected() {

--- a/modules/app-contentstudio/src/main/resources/assets/js/app/dialog/DependantItemsDialog.ts
+++ b/modules/app-contentstudio/src/main/resources/assets/js/app/dialog/DependantItemsDialog.ts
@@ -1,16 +1,11 @@
 import '../../api.ts';
 import {StatusSelectionItem} from './StatusSelectionItem';
 import {DependantItemViewer} from './DependantItemViewer';
-
-import ContentSummary = api.content.ContentSummary;
-import ContentIds = api.content.ContentIds;
 import ContentId = api.content.ContentId;
 import GetDescendantsOfContents = api.content.resource.GetDescendantsOfContentsRequest;
-import ContentSummaryAndCompareStatusFetcher = api.content.resource.ContentSummaryAndCompareStatusFetcher;
 import ContentSummaryAndCompareStatus = api.content.ContentSummaryAndCompareStatus;
 import CompareStatus = api.content.CompareStatus;
 import BrowseItem = api.app.browse.BrowseItem;
-import SelectionItem = api.app.browse.SelectionItem;
 import ListBox = api.ui.selector.list.ListBox;
 import LoadMask = api.ui.mask.LoadMask;
 import DialogButton = api.ui.dialog.DialogButton;
@@ -305,9 +300,11 @@ export class DialogItemList extends ListBox<ContentSummaryAndCompareStatus> {
 
         itemViewer.setObject(item);
 
-        let browseItem = new BrowseItem<ContentSummaryAndCompareStatus>(item).setId(item.getId()).setDisplayName(
-            item.getDisplayName()).setPath(item.getPath().toString()).setIconUrl(
-            new api.content.util.ContentIconUrlResolver().setContent(item.getContentSummary()).resolve());
+        let browseItem = <BrowseItem<ContentSummaryAndCompareStatus>>new BrowseItem<ContentSummaryAndCompareStatus>(item)
+            .setId(item.getId())
+            .setDisplayName(item.getDisplayName())
+            .setPath(item.getPath().toString())
+            .setIconUrl(new api.content.util.ContentIconUrlResolver().setContent(item.getContentSummary()).resolve());
 
         let statusItem = this.createSelectionItem(itemViewer, browseItem);
 
@@ -347,9 +344,11 @@ export class DialogDependantList extends ListBox<ContentSummaryAndCompareStatus>
 
         dependantViewer.setObject(item);
 
-        let browseItem = new BrowseItem<ContentSummaryAndCompareStatus>(item).setId(item.getId()).setDisplayName(
-            item.getDisplayName()).setPath(item.getPath().toString()).setIconUrl(
-            new api.content.util.ContentIconUrlResolver().setContent(item.getContentSummary()).resolve());
+        let browseItem = <BrowseItem<ContentSummaryAndCompareStatus>>new BrowseItem<ContentSummaryAndCompareStatus>(item)
+            .setId(item.getId())
+            .setDisplayName(item.getDisplayName())
+            .setPath(item.getPath().toString())
+            .setIconUrl(new api.content.util.ContentIconUrlResolver().setContent(item.getContentSummary()).resolve());
 
         let selectionItem = new StatusSelectionItem(dependantViewer, browseItem);
 

--- a/modules/app-users/src/main/resources/assets/js/app/browse/UserBrowsePanel.ts
+++ b/modules/app-users/src/main/resources/assets/js/app/browse/UserBrowsePanel.ts
@@ -115,8 +115,10 @@ export class UserBrowsePanel extends api.app.browse.BrowsePanel<UserTreeGridItem
         nodes.forEach((node: TreeNode<UserTreeGridItem>) => {
             let userGridItem = node.getData();
 
-            let item = new BrowseItem<UserTreeGridItem>(userGridItem).setId(userGridItem.getDataId()).setDisplayName(
-                userGridItem.getItemDisplayName()).setIconClass(this.selectIconClass(userGridItem));
+            let item = <BrowseItem<UserTreeGridItem>>new BrowseItem<UserTreeGridItem>(userGridItem)
+                .setId(userGridItem.getDataId())
+                .setDisplayName(userGridItem.getItemDisplayName())
+                .setIconClass(this.selectIconClass(userGridItem));
             browseItems.push(item);
 
         });

--- a/modules/app-users/src/main/resources/assets/js/app/browse/UserBrowsePanel.ts
+++ b/modules/app-users/src/main/resources/assets/js/app/browse/UserBrowsePanel.ts
@@ -6,8 +6,6 @@ import {UserBrowseItemPanel} from './UserBrowseItemPanel';
 import {UserTreeGridActions} from './UserTreeGridActions';
 import {PrincipalBrowseFilterPanel} from './filter/PrincipalBrowseFilterPanel';
 import {Router} from '../Router';
-
-import TreeGrid = api.ui.treegrid.TreeGrid;
 import TreeNode = api.ui.treegrid.TreeNode;
 import BrowseItem = api.app.browse.BrowseItem;
 import PrincipalType = api.security.PrincipalType;
@@ -108,19 +106,23 @@ export class UserBrowsePanel extends api.app.browse.BrowsePanel<UserTreeGridItem
         this.treeGrid.filter(this.treeGrid.getSelectedDataList());
     }
 
+    treeNodeToBrowseItem(node: TreeNode<UserTreeGridItem>): BrowseItem<UserTreeGridItem>|null {
+        const data = node ? node.getData() : null;
+        return !data ? null : <BrowseItem<UserTreeGridItem>>new BrowseItem<UserTreeGridItem>(data)
+            .setId(data.getDataId())
+            .setDisplayName(data.getItemDisplayName())
+            .setIconClass(this.selectIconClass(data));
+    }
+
     treeNodesToBrowseItems(nodes: TreeNode<UserTreeGridItem>[]): BrowseItem<UserTreeGridItem>[] {
         let browseItems: BrowseItem<UserTreeGridItem>[] = [];
 
         // do not proceed duplicated content. still, it can be selected
         nodes.forEach((node: TreeNode<UserTreeGridItem>) => {
-            let userGridItem = node.getData();
-
-            let item = <BrowseItem<UserTreeGridItem>>new BrowseItem<UserTreeGridItem>(userGridItem)
-                .setId(userGridItem.getDataId())
-                .setDisplayName(userGridItem.getItemDisplayName())
-                .setIconClass(this.selectIconClass(userGridItem));
-            browseItems.push(item);
-
+            const item = this.treeNodeToBrowseItem(node);
+            if (item) {
+                browseItems.push(item);
+            }
         });
         return browseItems;
     }

--- a/modules/app-users/src/main/resources/assets/js/app/browse/UserTreeGridActions.ts
+++ b/modules/app-users/src/main/resources/assets/js/app/browse/UserTreeGridActions.ts
@@ -34,7 +34,7 @@ export class UserTreeGridActions implements TreeGridActions<UserTreeGridItem> {
     }
 
     updateActionsEnabledState(browseItems: BrowseItem<UserTreeGridItem>[]): wemQ.Promise<void> {
-        return wemQ().then(() => {
+        return wemQ(true).then(() => {
             let userStoresSelected: number = 0;
             let principalsSelected: number = 0;
             let directoriesSelected: number = 0;

--- a/modules/app-users/src/main/resources/assets/js/app/browse/UserTreeGridActions.ts
+++ b/modules/app-users/src/main/resources/assets/js/app/browse/UserTreeGridActions.ts
@@ -10,6 +10,7 @@ import TreeGridActions = api.ui.treegrid.actions.TreeGridActions;
 import BrowseItem = api.app.browse.BrowseItem;
 import UserStore = api.security.UserStore;
 import User = api.security.User;
+import BrowseItemsChanges = api.app.browse.BrowseItemsChanges;
 
 export class UserTreeGridActions implements TreeGridActions<UserTreeGridItem> {
 
@@ -33,7 +34,7 @@ export class UserTreeGridActions implements TreeGridActions<UserTreeGridItem> {
         return this.actions;
     }
 
-    updateActionsEnabledState(browseItems: BrowseItem<UserTreeGridItem>[]): wemQ.Promise<void> {
+    updateActionsEnabledState(browseItems: BrowseItem<UserTreeGridItem>[], changes?: BrowseItemsChanges<UserTreeGridItem>): wemQ.Promise<void> {
         return wemQ(true).then(() => {
             let userStoresSelected: number = 0;
             let principalsSelected: number = 0;

--- a/modules/app-users/src/main/resources/assets/js/app/browse/UserTreeGridActions.ts
+++ b/modules/app-users/src/main/resources/assets/js/app/browse/UserTreeGridActions.ts
@@ -5,13 +5,10 @@ import {DeletePrincipalAction} from './action/DeletePrincipalAction';
 import {EditPrincipalAction} from './action/EditPrincipalAction';
 import {NewPrincipalAction} from './action/NewPrincipalAction';
 import {UserItemsTreeGrid} from './UserItemsTreeGrid';
-
 import Action = api.ui.Action;
 import TreeGridActions = api.ui.treegrid.actions.TreeGridActions;
 import BrowseItem = api.app.browse.BrowseItem;
-import PrincipalType = api.security.PrincipalType;
 import UserStore = api.security.UserStore;
-import GetPrincipalsByUserStoreRequest = api.security.GetPrincipalsByUserStoreRequest;
 import User = api.security.User;
 
 export class UserTreeGridActions implements TreeGridActions<UserTreeGridItem> {
@@ -36,59 +33,57 @@ export class UserTreeGridActions implements TreeGridActions<UserTreeGridItem> {
         return this.actions;
     }
 
-    updateActionsEnabledState(userItemBrowseItems: BrowseItem<UserTreeGridItem>[]): wemQ.Promise<BrowseItem<UserTreeGridItem>[]> {
-        let userStoresSelected: number = 0;
-        let principalsSelected: number = 0;
-        let directoriesSelected: number = 0;
-        let usersSelected: number = 0;
+    updateActionsEnabledState(browseItems: BrowseItem<UserTreeGridItem>[]): wemQ.Promise<void> {
+        return wemQ().then(() => {
+            let userStoresSelected: number = 0;
+            let principalsSelected: number = 0;
+            let directoriesSelected: number = 0;
+            let usersSelected: number = 0;
 
-        userItemBrowseItems.forEach((browseItem: BrowseItem<UserTreeGridItem>) => {
-            const item = <UserTreeGridItem>browseItem.getModel();
-            const itemType = item.getType();
-            switch (itemType) {
-            case UserTreeGridItemType.PRINCIPAL:
-                principalsSelected++;
-                if (api.ObjectHelper.iFrameSafeInstanceOf(item.getPrincipal(), User)) {
-                    usersSelected++;
+            browseItems.forEach((browseItem: BrowseItem<UserTreeGridItem>) => {
+                const item = <UserTreeGridItem>browseItem.getModel();
+                const itemType = item.getType();
+                switch (itemType) {
+                case UserTreeGridItemType.PRINCIPAL:
+                    principalsSelected++;
+                    if (api.ObjectHelper.iFrameSafeInstanceOf(item.getPrincipal(), User)) {
+                        usersSelected++;
+                    }
+                    break;
+                case UserTreeGridItemType.ROLES:
+                    directoriesSelected++;
+                    break;
+                case UserTreeGridItemType.GROUPS:
+                    directoriesSelected++;
+                    break;
+                case UserTreeGridItemType.USERS:
+                    directoriesSelected++;
+                    break;
+                case UserTreeGridItemType.USER_STORE:
+                    userStoresSelected++;
+                    break;
                 }
-                break;
-            case UserTreeGridItemType.ROLES:
-                directoriesSelected++;
-                break;
-            case UserTreeGridItemType.GROUPS:
-                directoriesSelected++;
-                break;
-            case UserTreeGridItemType.USERS:
-                directoriesSelected++;
-                break;
-            case UserTreeGridItemType.USER_STORE:
-                userStoresSelected++;
-                break;
+            });
+
+            const totalSelection = userStoresSelected + principalsSelected + directoriesSelected;
+            const anyPrincipal = principalsSelected > 0;
+            const anyUserStore = userStoresSelected > 0;
+            const onlyUsersSelected = totalSelection >= 1 && totalSelection === usersSelected;
+            const onePrincipalSelected = totalSelection === 1 && totalSelection === principalsSelected;
+
+            this.NEW.setEnabled(true);
+            this.EDIT.setEnabled(directoriesSelected < 1 && (anyUserStore || anyPrincipal));
+
+            if (onlyUsersSelected || onePrincipalSelected) {
+                this.DELETE.setEnabled(true);
+            } else if (totalSelection === 1) {
+                this.establishDeleteActionState((<BrowseItem<UserTreeGridItem>>browseItems[0]).getModel());
+            } else {
+                this.DELETE.setEnabled(false);
             }
+
+            this.SYNC.setEnabled(anyUserStore);
         });
-
-        const totalSelection = userStoresSelected + principalsSelected + directoriesSelected;
-        const anyPrincipal = principalsSelected > 0;
-        const anyUserStore = userStoresSelected > 0;
-        const onlyUsersSelected = totalSelection >= 1 && totalSelection === usersSelected;
-        const onePrincipalSelected = totalSelection === 1 && totalSelection === principalsSelected;
-
-        this.NEW.setEnabled(true);
-        this.EDIT.setEnabled(directoriesSelected < 1 && (anyUserStore || anyPrincipal));
-
-        if (onlyUsersSelected || onePrincipalSelected) {
-            this.DELETE.setEnabled(true);
-        } else if (totalSelection === 1) {
-            this.establishDeleteActionState((<BrowseItem<UserTreeGridItem>>userItemBrowseItems[0]).getModel());
-        } else {
-            this.DELETE.setEnabled(false);
-        }
-
-        this.SYNC.setEnabled(anyUserStore);
-
-        let deferred = wemQ.defer<BrowseItem<UserTreeGridItem>[]>();
-        deferred.resolve(userItemBrowseItems);
-        return deferred.promise;
     }
 
     private establishDeleteActionState(userBrowseItem: UserTreeGridItem) {


### PR DESCRIPTION
* Optimized `treeNodesToBrowseItems` usage, using single-item version, when creating an array of browse items is excessive.
* Refactored async calls.
* Refactored `TreeGridActions.updateActionsEnabledState()` to return empty promise.