### PR TITLE
PT-BR translation update

### DIFF
--- a/modules/app-contentstudio/src/main/resources/admin/i18n/phrases_pt.properties
+++ b/modules/app-contentstudio/src/main/resources/admin/i18n/phrases_pt.properties
@@ -4,8 +4,8 @@ app.abbr=CM
 #
 # Action
 #
-action.move=Mover
 action.deleteMore=Excluir...
+action.move=Mover
 action.duplicate=Duplicar
 action.moveMore=Mover...
 action.preview=Prévia
@@ -35,7 +35,7 @@ action.editIssue=Editar tarefa
 action.more=Mais
 action.actions=Ações
 action.view=Ver
-action.saveAsTemplate=Salvar como Templae
+action.saveAsTemplate=Salvar como Template
 action.rotate=Girar em sentido horário
 action.mirror=Espelhar
 
@@ -90,7 +90,7 @@ field.lastModified.lessDay=< 1 dia
 field.lastModified.lessWeek=< 1 semana
 field.readOnly=Este conteúdo é somente para leitura
 field.contentTypes=Tipos de Conteúdo
-field.mostPopular=Most Populares
+field.mostPopular=Mais Populares
 field.recentlyUsed=Usados Recentemente
 field.onlineFrom=Online desde
 field.onlineFrom.help=Itens Offline serão publicados na hora especificada
@@ -131,13 +131,13 @@ field.security=Segurança
 field.showComponent=Mostrar Visualização do Componente
 field.showInspection=Mostrar Painel de Inspeção
 field.publish.item=Publicar item {0}
-field.publish.status=O item foi {0}
+field.publish.status=Este item está {0}
 field.components=Componentes
 field.permissions.inheritsParent=Herdar permissões do item pai
 field.emulator=Emular diferentes tamanhos físicos de cliente
 field.image=Imagem
 field.image.help=Faça upload ou use imagens existentes
-field.part=Parte
+field.part=Bloco
 field.part.help=Componentes Avançados
 field.layout=Layout
 field.layout.help=Customizar layout da página
@@ -202,7 +202,7 @@ dialog.publish.editInvalid=Editar conteúdo inválido
 dialog.publish.showChildren=Mostrar itens filhos
 dialog.publish.excludeChildren=Excluir itens filhos
 dialog.publish.includeChildren=Incluir itens filhos
-dialog.publish.excludeFromPublishing=Exclude from publishing
+dialog.publish.excludeFromPublishing=Remover da Publicação
 dialog.unpublish=Despublicar item
 dialog.unpublish.subname=<b>Colocar Offline?</b> - Despublicar os itens selecionados mudarão o status de volta para offline
 dialog.unpublish.dependants=Itens Dependentes - Limpe as referências aos itens selecionados ou clique em Despublicar para colocar todos os itens offline
@@ -242,14 +242,14 @@ live.view.create.fragment=Criar Fragmento
 live.view.selectparent=Selecionar Pai
 live.view.insert=Inserir
 live.view.insert.image=Imagem
-live.view.insert.part=Parte
+live.view.insert.part=Bloco
 live.view.insert.layout=Layout
 live.view.insert.text=Texto
 live.view.insert.fragment=Fragmento
 live.view.fragment.notavailable=Fragmento {0} não se encontra disponível
-live.view.fragment.notfound=Fragment content could not be found Conteúdo do fragmento não pode ser encontrado
-live.view.fragment.notfoundid=Fragment {0} could not be found Fragmento {0} não pode ser encontrado
-live.view.fragment.editnewtab=Edit in new tab Editar em nova aba
+live.view.fragment.notfound=Conteúdo do fragmento não pode ser encontrado
+live.view.fragment.notfoundid=Fragmento {0} não pode ser encontrado
+live.view.fragment.editnewtab=Editar em nova aba
 live.view.drag.error.sourceandtargetnull=O Componente arrastado e novo item do tipo não podem ser nulos
 live.view.drag.error.compviewisnull=A visualização do Componente não esperava retornar nula
 live.view.drag.error.regionviewisnull=A visualização da Região não esperava retornar nula
@@ -292,3 +292,9 @@ widget.pagetemplate.forcedtemplate=Template da Página
 widget.pagetemplate.fragment=Fragmento
 widget.pagetemplate.default=Template da página não está sendo usada
 widget.pagetemplate.notfound=Não encontrado
+
+#
+# Tooltip
+#
+tooltip.combobox.treemode.enable = Mudar para o modo árvore
+tooltip.combobox.treemode.disable = Mude para o modo plano


### PR DESCRIPTION
In this update I've moved the "Move" key to the same line as the phrases.properties to get easier to compare when needed. Also, I've updated some translations that I see a better meaning when live in the Content Studio, like "Part" that now we use the translation for "Block". A missing translation to "Exclude from publishing" was fixed and two more tooltip translations were added. 