### PR TITLE
Fix the ESLint config path

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
 **/*.js
-!.eslintrc.js
 !modules/app-{applications,contentstudio,users}/src/main/resources/**/*.js
 modules/app-{applications,contentstudio,users}/src/main/resources/assets/page-editor/**/*.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
         'vars-on-top': 'off',
         'global-require': 'off',
         'no-use-before-define': ['error', { functions: false }],
+        'linebreak-style': ['off'],
         'prettier/prettier': [
             'error',
             {

--- a/modules/app-applications/package.json
+++ b/modules/app-applications/package.json
@@ -7,9 +7,9 @@
     "lint": "run-p -c --aggregate-output lint:*",
     "fix": "run-p -c --aggregate-output fix:*",
     "lint:ts": "tslint -c ../../tslint.json -e **/*.d.ts src/**/*.ts --noUnusedLocals",
-    "lint:js": "eslint ../../.eslintrc.js --ignore-path ../../.eslintignore .",
+    "lint:js": "eslint -c ../../.eslintrc.js --ignore-path ../../.eslintignore .",
     "fix:ts": "tslint -c ../../tslint.json -e **/*.d.ts src/**/*.ts --fix --noUnusedLocals",
-    "fix:js": "eslint ../../.eslintrc.js --ignore-path ../../.eslintignore . --fix"
+    "fix:js": "eslint -c ../../.eslintrc.js --ignore-path ../../.eslintignore . --fix"
   },
   "devDependencies": {
     "error-logger-webpack-plugin": "0.0.1",

--- a/modules/app-contentstudio/package.json
+++ b/modules/app-contentstudio/package.json
@@ -7,9 +7,9 @@
     "lint": "run-p -c --aggregate-output lint:*",
     "fix": "run-p -c --aggregate-output fix:*",
     "lint:ts": "tslint -c ../../tslint.json -e **/*.d.ts src/**/*.ts --noUnusedLocals",
-    "lint:js": "eslint ../../.eslintrc.js --ignore-path ../../.eslintignore .",
+    "lint:js": "eslint -c ../../.eslintrc.js --ignore-path ../../.eslintignore .",
     "fix:ts": "tslint -c ../../tslint.json -e **/*.d.ts src/**/*.ts --fix --noUnusedLocals",
-    "fix:js": "eslint ../../.eslintrc.js --ignore-path ../../.eslintignore . --fix"
+    "fix:js": "eslint -c ../../.eslintrc.js --ignore-path ../../.eslintignore . --fix"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.6",

--- a/modules/app-users/package.json
+++ b/modules/app-users/package.json
@@ -7,9 +7,9 @@
     "lint": "run-p -c --aggregate-output lint:*",
     "fix": "run-p -c --aggregate-output fix:*",
     "lint:ts": "tslint -c ../../tslint.json -e **/*.d.ts src/**/*.ts --noUnusedLocals",
-    "lint:js": "eslint ../../.eslintrc.js --ignore-path ../../.eslintignore .",
+    "lint:js": "eslint -c ../../.eslintrc.js --ignore-path ../../.eslintignore .",
     "fix:ts": "tslint -c ../../tslint.json -e **/*.d.ts src/**/*.ts --fix --noUnusedLocals",
-    "fix:js": "eslint ../../.eslintrc.js --ignore-path ../../.eslintignore . --fix"
+    "fix:js": "eslint -c ../../.eslintrc.js --ignore-path ../../.eslintignore . --fix"
   },
   "devDependencies": {
     "error-logger-webpack-plugin": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "build:app-contentstudio": "npm run --prefix modules/app-contentstudio/ build",
     "build:app-main": "npm run --prefix modules/app-main/ build",
     "build:app-users": "npm run --prefix modules/app-users/ build",
-    "lint:ts": "tslint modules/**/**/src/main/resources/**/*.ts --exclude **/*.d.ts --noUnusedLocals",
-    "lint:js": "eslint modules/app-{applications,contentstudio,users}/src/main/**/*.js",
-    "fix:ts": "tslint modules/**/src/main/resources/**/*.ts --fix --exclude **/*.d.ts --noUnusedLocals",
-    "fix:js": "eslint modules/app-{applications,contentstudio,users}/src/main/**/*.js --fix"
+    "lint:ts": "tslint -c tslint.json modules/**/**/src/main/resources/**/*.ts --exclude **/*.d.ts --noUnusedLocals",
+    "lint:js": "eslint -c .eslintrc.js modules/app-{applications,contentstudio,users}/src/main/**/*.js",
+    "fix:ts": "tslint -c tslint.json modules/**/src/main/resources/**/*.ts --fix --exclude **/*.d.ts --noUnusedLocals",
+    "fix:js": "eslint -c .eslintrc.js modules/app-{applications,contentstudio,users}/src/main/**/*.js --fix"
   },
   "devDependencies": {
     "eslint": "^3.19.0",


### PR DESCRIPTION
__Common quick fixes for linting:__
* Fixed passed config file argument in scripts;
* Disabled `linebreak` check by ESLint (May result in linting problems on some machines with a specific configuration of Git/IDE otherwise);
* Added config arguments in root lint scripts (for some reason, ESLint doesn't see the config file, if it's not passed in CLI explicitly).