### PR TITLE
 Enable discarding new unsaved content #181

### DIFF
--- a/modules/app-contentstudio/src/main/resources/admin/i18n/phrases.properties
+++ b/modules/app-contentstudio/src/main/resources/admin/i18n/phrases.properties
@@ -48,6 +48,7 @@ notify.edit.tooMuch=Editing too much content may affect the performance. Please 
 notify.preview.tooMuch=Number of selected items exceeds maximum number allowed for preview ({0}). Please deselect some of the items.
 notify.process.failed=Processing failed: {0}.
 notify.content.deleteError=Content could not be deleted.
+notify.content.discard=This content was not saved and will be deleted upon exit. Save the changes to keep it.
 notify.widget.error=Could not load widget descriptors.
 notify.version.changed=Version successfully changed to {0}.
 notify.app.missing=Required application "{0}" is not available.

--- a/modules/app-contentstudio/src/main/resources/admin/i18n/phrases_ru.properties
+++ b/modules/app-contentstudio/src/main/resources/admin/i18n/phrases_ru.properties
@@ -298,3 +298,4 @@ widget.pagetemplate.notfound=Не найден
 #
 tooltip.combobox.treemode.enable = Переключиться в режим дерева
 tooltip.combobox.treemode.disable = Переключиться в режим списка
+notify.content.discard=Этот контент не был сохранен и будет удален при выходе. Сохраните изменения чтобы оставить их.

--- a/modules/app-contentstudio/src/main/resources/assets/js/app/view/DeleteAction.ts
+++ b/modules/app-contentstudio/src/main/resources/assets/js/app/view/DeleteAction.ts
@@ -22,7 +22,7 @@ export class DeleteAction extends api.ui.Action {
                     if (reason && reason.message) {
                         api.notify.showError(reason.message);
                     } else {
-                        api.notify.showError(i18n('notify.content.deleteError');
+                        api.notify.showError(i18n('notify.content.deleteError'));
                     }
                 }).done();
             });


### PR DESCRIPTION
* Added discard notification with some hacks for specific browsers:
  * Firefox won't send a request, unless it's synchronous.
  * Synchronous may not work in other browsers.
  * Chrome and other WebKit-based browsers won't render notification or any DOM element before the default pop-up from `beforeunload` event.
* Added discard notification message.

* Fix missing parenthesis