### PR TITLE
Fix linting

### DIFF
--- a/modules/app-applications/build.gradle
+++ b/modules/app-applications/build.gradle
@@ -29,6 +29,7 @@ task lint( type: NpmTask, dependsOn: npmInstall ) {
     args = ['run', 'lint']
     inputs.files fileTree( dir: 'modules', include: '**/src/main/**.*' )
     outputs.dir file('gradle')
+    outputs.upToDateWhen { false }
 }
 
 task webpack( type: NodeTask, dependsOn: lint ) {

--- a/modules/app-contentstudio/build.gradle
+++ b/modules/app-contentstudio/build.gradle
@@ -32,6 +32,7 @@ task lint( type: NpmTask, dependsOn: npmInstall ) {
     args = ['run', 'lint']
     inputs.files fileTree( dir: 'modules', include: '**/src/main/**.*' )
     outputs.dir file('gradle')
+    outputs.upToDateWhen { false }
 }
 
 task webpack( type: NodeTask, dependsOn: lint ) {

--- a/modules/app-users/build.gradle
+++ b/modules/app-users/build.gradle
@@ -37,6 +37,7 @@ task lint( type: NpmTask, dependsOn: npmInstall ) {
     args = ['run', 'lint']
     inputs.files fileTree( dir: 'modules', include: '**/src/main/**.*' )
     outputs.dir file('gradle')
+    outputs.upToDateWhen { false }
 }
 
 task webpack( type: NodeTask, dependsOn: lint ) {


### PR DESCRIPTION
Updated Gradle `lint` task to never be UP-TO-DATE, so it will always run, indicating errors. For faster builds just skip it with the flag `-x lint`.