### PR TITLE
Add buildAll task to build project without linting in lib-admin-ui 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
 
 install: true
 script:
-  - ./gradlew build -Pci --stacktrace --no-daemon
+  - ./gradlew build --stacktrace --no-daemon
 
 cache:
   directories:

--- a/build.gradle
+++ b/build.gradle
@@ -14,5 +14,7 @@ subprojects {
 }
 
 task buildAll {
-    dependsOn gradle.includedBuild( 'lib-admin-ui' ).task( ':buildNoLint' )
+    if (gradle.libAdminUi) {
+        dependsOn gradle.includedBuild( 'lib-admin-ui' ).task( ':buildNoLint' )
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,12 +9,10 @@ allprojects {
 
 subprojects {
     apply plugin: 'java'
-    task buildAll
-    tasks.buildAll.dependsOn(build)
 }
 
-task buildAll {
-    if (gradle.libAdminUi) {
+task build {
+    if (project.hasProperty('all')) {
         dependsOn gradle.includedBuild( 'lib-admin-ui' ).task( ':buildNoLint' )
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,12 @@ allprojects {
     group = 'com.enonic.xp'
 }
 
-// If not CI (don't have `ci` property), disable linting in `lib-admin-ui` dependent build
-if (!project.hasProperty('ci')) {
-    task build {
-        dependsOn gradle.includedBuild( 'lib-admin-ui' ).task( ':buildNoLint' )
-    }
+subprojects {
+    apply plugin: 'java'
+    task buildAll
+    tasks.buildAll.dependsOn(build)
+}
+
+task buildAll {
+    dependsOn gradle.includedBuild( 'lib-admin-ui' ).task( ':buildNoLint' )
 }

--- a/gradle/defaults.gradle
+++ b/gradle/defaults.gradle
@@ -6,6 +6,7 @@ app {
 
 // Add repositories
 repositories {
+    mavenLocal()
     jcenter()
     xp.enonicRepo()
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ include ':app-contentstudio'
 include ':app-users'
 
 addBuild('../xp')
-addBuild('../lib-admin-ui')
+gradle.ext.libAdminUi = addBuild('../lib-admin-ui')
 
 rootProject.name = 'xp-apps'
 
@@ -31,4 +31,6 @@ def addBuild( name )
     if (dir.directory) {
         includeBuild name
     }
+
+    return dir.exists()
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,8 +4,11 @@ include ':app-applications'
 include ':app-contentstudio'
 include ':app-users'
 
-addBuild('../xp')
-gradle.ext.libAdminUi = addBuild('../lib-admin-ui')
+
+if (startParameter.getProjectProperties().containsKey('all')) {
+    addBuild('../xp')
+    addBuild('../lib-admin-ui')
+}
 
 rootProject.name = 'xp-apps'
 
@@ -31,6 +34,4 @@ def addBuild( name )
     if (dir.directory) {
         includeBuild name
     }
-
-    return dir.exists()
 }


### PR DESCRIPTION
Restored the default behavior of the `build` task.
Added `buildAll` task to run the composite build without linting of the `lib-admin-ui` dependency.
Added check for the included `lib-admin-ui` dependency (mainly for CI).