### PR TITLE
Auth Lib - Add function 'getUserstore' #430

### DIFF
--- a/modules/app-users/src/main/resources/assets/js/api/graphql/userStore/GetUserStoreByKeyRequest.ts
+++ b/modules/app-users/src/main/resources/assets/js/api/graphql/userStore/GetUserStoreByKeyRequest.ts
@@ -22,10 +22,7 @@ export class GetUserStoreByKeyRequest
     getQuery(): string {
         return `query($key: String!) {
             userStore(key: $key) {
-                id,
                 key,
-                name,
-                path,
                 displayName,
                 description,
                 authConfig {
@@ -33,7 +30,6 @@ export class GetUserStoreByKeyRequest
                     config
                 }
                 idProviderMode,
-                modifiedTime,
                 permissions {
                     principal {
                         displayName

--- a/modules/app-users/src/main/resources/assets/js/app/UserAppPanel.ts
+++ b/modules/app-users/src/main/resources/assets/js/app/UserAppPanel.ts
@@ -1,5 +1,5 @@
 import '../api.ts';
-import {UserTreeGridItem, UserTreeGridItemType, UserTreeGridItemBuilder} from './browse/UserTreeGridItem';
+import {UserTreeGridItem, UserTreeGridItemBuilder, UserTreeGridItemType} from './browse/UserTreeGridItem';
 import {UserItemWizardPanel} from './wizard/UserItemWizardPanel';
 import {UserStoreWizardPanel} from './wizard/UserStoreWizardPanel';
 import {PrincipalWizardPanel} from './wizard/PrincipalWizardPanel';
@@ -11,9 +11,8 @@ import {PrincipalWizardPanelParams} from './wizard/PrincipalWizardPanelParams';
 import {RoleWizardPanel} from './wizard/RoleWizardPanel';
 import {UserWizardPanel} from './wizard/UserWizardPanel';
 import {GroupWizardPanel} from './wizard/GroupWizardPanel';
-import GetUserStoreByKeyRequest  = api.security.GetUserStoreByKeyRequest;
+import {GetUserStoreByKeyRequest} from '../api/graphql/userStore/GetUserStoreByKeyRequest';
 import {GetPrincipalByKeyRequest} from '../api/graphql/principal/GetPrincipalByKeyRequest';
-
 import AppBarTabMenuItem = api.app.bar.AppBarTabMenuItem;
 import AppBarTabMenuItemBuilder = api.app.bar.AppBarTabMenuItemBuilder;
 import AppBarTabId = api.app.bar.AppBarTabId;
@@ -21,7 +20,6 @@ import Principal = api.security.Principal;
 import PrincipalType = api.security.PrincipalType;
 import PrincipalKey = api.security.PrincipalKey;
 import UserStore = api.security.UserStore;
-import ShowBrowsePanelEvent = api.app.ShowBrowsePanelEvent;
 import UserItem = api.security.UserItem;
 import i18n = api.util.i18n;
 

--- a/modules/app-users/src/main/resources/assets/js/app/wizard/UserStoreWizardDataLoader.ts
+++ b/modules/app-users/src/main/resources/assets/js/app/wizard/UserStoreWizardDataLoader.ts
@@ -1,7 +1,6 @@
 import '../../api.ts';
 import {UserStoreWizardPanelParams} from './UserStoreWizardPanelParams';
-import GetUserStoreByKeyRequest = api.security.GetUserStoreByKeyRequest;
-
+import {GetUserStoreByKeyRequest} from '../../api/graphql/userStore/GetUserStoreByKeyRequest';
 import UserStore = api.security.UserStore;
 
 export class UserStoreWizardDataLoader {

--- a/modules/app-users/src/main/resources/assets/js/app/wizard/UserStoreWizardPanel.ts
+++ b/modules/app-users/src/main/resources/assets/js/app/wizard/UserStoreWizardPanel.ts
@@ -106,8 +106,7 @@ export class UserStoreWizardPanel
     }
 
     protected doLayoutPersistedItem(persistedItem: UserStore): Q.Promise<void> {
-
-        if (!!persistedItem) {
+        if (persistedItem) {
             this.getWizardHeader().setDisplayName(persistedItem.getDisplayName());
             this.userStoreWizardStepForm.layout(persistedItem);
             this.permissionsWizardStepForm.layout(persistedItem, this.defaultUserStore);

--- a/modules/app-users/src/main/resources/lib/userstores.js
+++ b/modules/app-users/src/main/resources/lib/userstores.js
@@ -1,4 +1,5 @@
 var common = require('./common');
+var authLib = require('/lib/xp/auth');
 
 var Permission = {
     READ: 'READ',
@@ -47,6 +48,16 @@ var Access = {
 };
 
 module.exports = {
+    getByKey: function (key) {
+        var args = {key: key};
+        var userstore = authLib.getUserStore(args);
+        if (userstore != null) {
+            var authDescriptor = authLib.getAuthDescriptor(args);
+            userstore.idProviderMode = authDescriptor ? authDescriptor.mode : null;
+            userstore.permissions = authLib.getUserstorePermissions(args);
+        }
+        return userstore;
+    },
     getByKeys: function(keys) {
         var result = common.queryAll({
             query:

--- a/modules/app-users/src/main/resources/services/graphql/schema/query.js
+++ b/modules/app-users/src/main/resources/services/graphql/schema/query.js
@@ -25,13 +25,13 @@ module.exports = graphQl.createObjectType({
             }
         },
         userStore: {
-            type: graphQlObjectTypes.UserStoreType,
+            type: graphQlObjectTypes.PlainUserStoreType,
             args: {
                 key: graphQl.nonNull(graphQl.GraphQLString)
             },
             resolve: function(env) {
                 var key = env.args.key;
-                return userstores.getByKeys(key);
+                return userstores.getByKey(key);
             }
         },
         principalsConnection: {

--- a/modules/app-users/src/main/resources/services/graphql/types/objects/index.js
+++ b/modules/app-users/src/main/resources/services/graphql/types/objects/index.js
@@ -7,6 +7,7 @@ var graphQlTypes = require('./types');
 
 module.exports = {
     UserStoreType: graphQlUserStore.UserStoreType,
+    PlainUserStoreType: graphQlUserStore.PlainUserStoreType,
     UserStoreDeleteType: graphQlUserStore.UserStoreDeleteType,
     PrincipalType: graphQlPrincipal.PrincipalType,
     PrincipalDeleteType: graphQlPrincipal.PrincipalDeleteType,

--- a/modules/app-users/src/main/resources/services/graphql/types/objects/userStore.js
+++ b/modules/app-users/src/main/resources/services/graphql/types/objects/userStore.js
@@ -6,6 +6,8 @@ var graphQlEnums = require('../enums');
 
 var graphQlUserItem = require('./userItem');
 
+var graphQlPrincipal = require('./principal');
+
 var UserStoreAccessControlEntryType = graphQl.createObjectType({
     name: 'UserStoreAccessControlEntry',
     description: 'Domain representation of user store access control entry',
@@ -22,6 +24,19 @@ var UserStoreAccessControlEntryType = graphQl.createObjectType({
     }
 });
 
+var Permissions = graphQl.createObjectType({
+    name: 'Permissions',
+    description: 'Permissions of the UserStore',
+    fields: {
+        principal: {
+            type: graphQlPrincipal.PrincipalType
+        },
+        access: {
+            type: graphQlEnums.UserStoreAccessEnum
+        }
+    }
+});
+
 exports.AuthConfig = graphQl.createObjectType({
     name: 'AuthConfig',
     description: 'Domain representation of auth config for user store',
@@ -31,9 +46,8 @@ exports.AuthConfig = graphQl.createObjectType({
         },
         config: {
             type: graphQl.GraphQLString,
-            resolve: function() {
-                // TODO: config is not read from db yet, and there's no suitable graphql type for unstructured data
-                return JSON.stringify([]);
+            resolve: function (env) {
+                return JSON.stringify(env.source.config);
             }
         }
     }
@@ -98,6 +112,35 @@ exports.UserStoreType = graphQl.createObjectType({
     }
 });
 graphQlUserItem.typeResolverMap.userStoreType = exports.UserStoreType;
+
+exports.PlainUserStoreType = graphQl.createObjectType({
+    name: 'PlainUserStoreType',
+    description: 'Domain representation of a user store',
+    interfaces: [graphQlUserItem.UserItemType],
+    fields: {
+        key: {
+            type: graphQl.GraphQLString,
+            resolve: function (env) {
+                return env.source.key;
+            }
+        },
+        description: {
+            type: graphQl.GraphQLString
+        },
+        displayName: {
+            type: graphQl.GraphQLString
+        },
+        authConfig: {
+            type: exports.AuthConfig
+        },
+        idProviderMode: {
+            type: graphQlEnums.IdProviderModeEnum
+        },
+        permissions: {
+            type: graphQl.list(Permissions)
+        }
+    }
+});
 
 exports.UserStoreDeleteType = graphQl.createObjectType({
     name: 'UserStoreDelete',


### PR DESCRIPTION
* Restored GraphQL requests for `UserStoreWizard`.
* Added `PlainUserStoreType` GraphQL type, that should be removed, when all UserStore methods are implemented and old are removed.
* Added `Permissions` type.
* Updated `AuthConfig` type by removing config stub.