### PR TITLE
Page Component View - regions are not displayed on the view, when a l…

### DIFF
--- a/modules/app-contentstudio/src/main/resources/assets/js/app/wizard/PageComponentsGridDragHandler.ts
+++ b/modules/app-contentstudio/src/main/resources/assets/js/app/wizard/PageComponentsGridDragHandler.ts
@@ -7,6 +7,7 @@ import {RegionView} from '../../page-editor/RegionView';
 import {LayoutComponentView} from '../../page-editor/layout/LayoutComponentView';
 import {FragmentComponentView} from '../../page-editor/fragment/FragmentComponentView';
 import {PageView} from '../../page-editor/PageView';
+import {RegionItemType} from '../../page-editor/RegionItemType';
 import GridDragHandler = api.ui.grid.GridDragHandler;
 import TreeNode = api.ui.treegrid.TreeNode;
 import Component = api.content.page.region.Component;
@@ -67,11 +68,12 @@ export class PageComponentsGridDragHandler
 
         let insertPosition = (draggableRow > insertBefore) ? insertBefore : insertBefore + 1;
 
-        this.updateDragHelperStatus(draggableRow, insertPosition, dataList);
-
         if (DragHelper.get().isDropAllowed()) {
             super.handleBeforeMoveRows(event, data);
         }
+
+        this.updateDragHelperStatus(draggableRow, insertPosition, dataList);
+
         return true;
     }
 
@@ -107,6 +109,10 @@ export class PageComponentsGridDragHandler
         let insertIndex = insertData.insertIndex;
 
         let newParent = data[regionPosition];
+
+        if (!newParent.getData().getType().equals(RegionItemType.get())) {
+            return;
+        }
 
         if (newParent === item.getParent() && data.indexOf(item) < insertBefore) {
             insertIndex--;

--- a/modules/app-contentstudio/src/main/resources/assets/js/app/wizard/PageComponentsView.ts
+++ b/modules/app-contentstudio/src/main/resources/assets/js/app/wizard/PageComponentsView.ts
@@ -216,8 +216,9 @@ export class PageComponentsView
                         }
 
                         if (this.tree.hasChildren(event.getComponentView())) {
-                            let componentNode = this.tree.getRoot().getCurrentRoot().findNode(
-                                this.tree.getDataId(event.getComponentView()));
+                            const componentDataId = this.tree.getDataId(event.getComponentView());
+                            const componentNode = this.tree.getRoot().getCurrentRoot().findNode(componentDataId);
+
                             if (event.isDragged()) {
                                 this.tree.collapseNode(componentNode, true);
                             } else {
@@ -274,7 +275,6 @@ export class PageComponentsView
                                      oldComponentView: ComponentView<Component>): wemQ.Promise<void> {
         const oldDataId = this.tree.getDataId(oldComponentView);
         const oldNode = this.tree.getRoot().getCurrentRoot().findNode(oldDataId);
-        const prevSibling = this.tree.getRowByNode(oldNode).prev();
 
         if (this.tree.hasChildren(oldComponentView)) {
             oldNode.removeChildren();
@@ -283,11 +283,6 @@ export class PageComponentsView
 
         return this.tree.updateNode(componentView, oldDataId).then(() => {
             const dataId = this.tree.getDataId(componentView);
-            const node = this.tree.getRoot().getCurrentRoot().findNode(dataId);
-            const row = this.tree.getRowByNode(node);
-
-            row.insertAfter(prevSibling);
-
             if (componentView.isSelected()) {
                 this.tree.selectNode(dataId);
                 this.scrollToItem(dataId);

--- a/modules/app-contentstudio/src/main/resources/assets/js/app/wizard/PageComponentsView.ts
+++ b/modules/app-contentstudio/src/main/resources/assets/js/app/wizard/PageComponentsView.ts
@@ -282,6 +282,7 @@ export class PageComponentsView
         }
 
         return this.tree.updateNode(componentView, oldDataId).then(() => {
+            this.tree.invalidate();
             const dataId = this.tree.getDataId(componentView);
             if (componentView.isSelected()) {
                 this.tree.selectNode(dataId);

--- a/modules/app-contentstudio/src/main/resources/assets/js/app/wizard/PageComponentsView.ts
+++ b/modules/app-contentstudio/src/main/resources/assets/js/app/wizard/PageComponentsView.ts
@@ -10,6 +10,7 @@ import {ItemViewDeselectedEvent} from '../../page-editor/ItemViewDeselectedEvent
 import {ComponentAddedEvent} from '../../page-editor/ComponentAddedEvent';
 import {TextComponentView} from '../../page-editor/text/TextComponentView';
 import {FragmentComponentView} from '../../page-editor/fragment/FragmentComponentView';
+import {LayoutComponentView} from '../../page-editor/layout/LayoutComponentView';
 import {ComponentRemovedEvent} from '../../page-editor/ComponentRemovedEvent';
 import {ComponentLoadedEvent} from '../../page-editor/ComponentLoadedEvent';
 import {ComponentResetEvent} from '../../page-editor/ComponentResetEvent';
@@ -229,10 +230,6 @@ export class PageComponentsView
                         if (api.ObjectHelper.iFrameSafeInstanceOf(event.getComponentView(), TextComponentView)) {
                             this.bindTreeTextNodeUpdateOnTextComponentModify(<TextComponentView>event.getComponentView());
                         }
-                        if (api.ObjectHelper.iFrameSafeInstanceOf(event.getComponentView(), FragmentComponentView)) {
-                            this.bindTreeFragmentNodeUpdateOnComponentLoaded(<FragmentComponentView>event.getComponentView());
-                            this.bindFragmentLoadErrorHandler(<FragmentComponentView>event.getComponentView());
-                        }
 
                         this.constrainToParent();
                         this.highlightInvalidItems();
@@ -252,12 +249,17 @@ export class PageComponentsView
 
         this.liveEditPage.onComponentLoaded((event: ComponentLoadedEvent) => {
             this.refreshComponentViewNode(event.getNewComponentView(), event.getOldComponentView()).then(() => {
-                if (api.ObjectHelper.iFrameSafeInstanceOf(event.getNewComponentView(), TextComponentView)) {
-                    this.bindTreeTextNodeUpdateOnTextComponentModify(<TextComponentView>event.getNewComponentView());
-                }
                 if (api.ObjectHelper.iFrameSafeInstanceOf(event.getNewComponentView(), FragmentComponentView)) {
                     this.bindTreeFragmentNodeUpdateOnComponentLoaded(<FragmentComponentView>event.getNewComponentView());
                     this.bindFragmentLoadErrorHandler(<FragmentComponentView>event.getNewComponentView());
+                    return;
+                }
+                if (api.ObjectHelper.iFrameSafeInstanceOf(event.getNewComponentView(), LayoutComponentView)) {
+                    const componentDataId = this.tree.getDataId(event.getNewComponentView());
+                    const componentNode = this.tree.getRoot().getCurrentRoot().findNode(componentDataId);
+
+                    this.tree.expandNode(componentNode);
+                    return;
                 }
             });
         });


### PR DESCRIPTION
…ayout has been inserted #447

Removed `row.insertAfter(prevSibling)` behaviour, since it make the expanded node to disappear after the update.