### PR TITLE
Users App - GraphQL - Update user store #463

### DIFF
--- a/modules/app-users/src/main/java/com/enonic/xp/app/users/lib/auth/AbstractUserStoreHandler.java
+++ b/modules/app-users/src/main/java/com/enonic/xp/app/users/lib/auth/AbstractUserStoreHandler.java
@@ -1,0 +1,25 @@
+package com.enonic.xp.app.users.lib.auth;
+
+import java.util.function.Supplier;
+
+import com.enonic.xp.script.bean.BeanContext;
+import com.enonic.xp.script.bean.ScriptBean;
+import com.enonic.xp.security.PrincipalKey;
+import com.enonic.xp.security.SecurityService;
+
+public abstract class AbstractUserStoreHandler
+    implements ScriptBean
+{
+    protected Supplier<SecurityService> securityService;
+
+    protected boolean isPrincipalExists( final PrincipalKey principalKey )
+    {
+        return securityService.get().getPrincipal( principalKey ).isPresent();
+    }
+
+    @Override
+    public void initialize( final BeanContext context )
+    {
+        this.securityService = context.getService( SecurityService.class );
+    }
+}

--- a/modules/app-users/src/main/java/com/enonic/xp/app/users/lib/auth/CreateUserStoreHandler.java
+++ b/modules/app-users/src/main/java/com/enonic/xp/app/users/lib/auth/CreateUserStoreHandler.java
@@ -1,25 +1,14 @@
 package com.enonic.xp.app.users.lib.auth;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-
 import com.enonic.xp.script.ScriptValue;
-import com.enonic.xp.script.bean.BeanContext;
-import com.enonic.xp.script.bean.ScriptBean;
 import com.enonic.xp.security.AuthConfig;
 import com.enonic.xp.security.CreateUserStoreParams;
-import com.enonic.xp.security.PrincipalKey;
-import com.enonic.xp.security.SecurityService;
 import com.enonic.xp.security.UserStore;
 import com.enonic.xp.security.UserStoreKey;
-import com.enonic.xp.security.acl.UserStoreAccess;
-import com.enonic.xp.security.acl.UserStoreAccessControlEntry;
 import com.enonic.xp.security.acl.UserStoreAccessControlList;
 
 public final class CreateUserStoreHandler
-    implements ScriptBean
+    extends AbstractUserStoreHandler
 {
     private String name;
 
@@ -30,8 +19,6 @@ public final class CreateUserStoreHandler
     private AuthConfig authConfig;
 
     private UserStoreAccessControlList permissions;
-
-    private Supplier<SecurityService> securityService;
 
     public void setName( final String name )
     {
@@ -55,7 +42,9 @@ public final class CreateUserStoreHandler
 
     public void setPermissions( final ScriptValue permissions )
     {
-        this.permissions = createPermissions( permissions );
+        this.permissions = permissions == null
+            ? null
+            : ScriptValueToUserStoreAccessControlListTranslator.translate( permissions, this::isPrincipalExists );
     }
 
     public UserStoreMapper createUserStore()
@@ -70,39 +59,5 @@ public final class CreateUserStoreHandler
             build();
         final UserStore userStore = securityService.get().createUserStore( params );
         return userStore == null ? null : new UserStoreMapper( userStore );
-    }
-
-    private UserStoreAccessControlList createPermissions( final ScriptValue permissions )
-    {
-        if ( permissions != null )
-        {
-            final List<UserStoreAccessControlEntry> entries = permissions.getArray().stream().
-                map( this::createAccessControlEntry ).
-                filter( Objects::nonNull ).
-                collect( Collectors.toList() );
-            return UserStoreAccessControlList.create().addAll( entries ).build();
-        }
-
-        return null;
-    }
-
-    private UserStoreAccessControlEntry createAccessControlEntry( ScriptValue scriptValue )
-    {
-        final String principalValue =
-            scriptValue.hasMember( "principal" ) ? scriptValue.getMember( "principal" ).getValue().toString() : null;
-        final String accessValue = scriptValue.hasMember( "access" ) ? scriptValue.getMember( "access" ).getValue().toString() : null;
-
-        final PrincipalKey principalKey = principalValue == null ? null : PrincipalKey.from( principalValue );
-        final UserStoreAccess access = UserStoreAccess.valueOf( accessValue );
-
-        final boolean hasPrincipal = principalValue != null && securityService.get().getPrincipal( principalKey ).isPresent();
-
-        return hasPrincipal ? UserStoreAccessControlEntry.create().principal( principalKey ).access( access ).build() : null;
-    }
-
-    @Override
-    public void initialize( final BeanContext context )
-    {
-        securityService = context.getService( SecurityService.class );
     }
 }

--- a/modules/app-users/src/main/java/com/enonic/xp/app/users/lib/auth/GetUserStoreHandler.java
+++ b/modules/app-users/src/main/java/com/enonic/xp/app/users/lib/auth/GetUserStoreHandler.java
@@ -1,19 +1,12 @@
 package com.enonic.xp.app.users.lib.auth;
 
-import java.util.function.Supplier;
-
-import com.enonic.xp.script.bean.BeanContext;
-import com.enonic.xp.script.bean.ScriptBean;
-import com.enonic.xp.security.SecurityService;
 import com.enonic.xp.security.UserStore;
 import com.enonic.xp.security.UserStoreKey;
 
 public final class GetUserStoreHandler
-    implements ScriptBean
+    extends AbstractUserStoreHandler
 {
     private UserStoreKey userStoreKey;
-
-    private Supplier<SecurityService> securityService;
 
     public void setUserStoreKey( final String userStoreKey )
     {
@@ -24,11 +17,5 @@ public final class GetUserStoreHandler
     {
         final UserStore userStore = securityService.get().getUserStore( userStoreKey );
         return userStore == null ? null : new UserStoreMapper( userStore );
-    }
-
-    @Override
-    public void initialize( final BeanContext context )
-    {
-        securityService = context.getService( SecurityService.class );
     }
 }

--- a/modules/app-users/src/main/java/com/enonic/xp/app/users/lib/auth/GetUserStoresHandler.java
+++ b/modules/app-users/src/main/java/com/enonic/xp/app/users/lib/auth/GetUserStoresHandler.java
@@ -1,30 +1,18 @@
 package com.enonic.xp.app.users.lib.auth;
 
 import java.util.List;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import com.enonic.xp.script.bean.BeanContext;
-import com.enonic.xp.script.bean.ScriptBean;
-import com.enonic.xp.security.SecurityService;
 import com.enonic.xp.security.UserStores;
 
 public final class GetUserStoresHandler
-    implements ScriptBean
+    extends AbstractUserStoreHandler
 {
-    private Supplier<SecurityService> securityService;
-
     public List<UserStoreMapper> getUserStores()
     {
         final UserStores userStores = securityService.get().getUserStores();
         return userStores.stream().
             map( userStore -> new UserStoreMapper( userStore ) ).
             collect( Collectors.toList() );
-    }
-
-    @Override
-    public void initialize( final BeanContext context )
-    {
-        securityService = context.getService( SecurityService.class );
     }
 }

--- a/modules/app-users/src/main/java/com/enonic/xp/app/users/lib/auth/ModifyUserStoreHandler.java
+++ b/modules/app-users/src/main/java/com/enonic/xp/app/users/lib/auth/ModifyUserStoreHandler.java
@@ -1,0 +1,88 @@
+package com.enonic.xp.app.users.lib.auth;
+
+import com.enonic.xp.script.ScriptValue;
+import com.enonic.xp.security.EditableUserStore;
+import com.enonic.xp.security.UpdateUserStoreParams;
+import com.enonic.xp.security.UserStore;
+import com.enonic.xp.security.UserStoreEditor;
+import com.enonic.xp.security.UserStoreKey;
+import com.enonic.xp.security.acl.UserStoreAccessControlList;
+
+public final class ModifyUserStoreHandler
+    extends AbstractUserStoreHandler
+{
+    private UserStoreKey userStoreKey;
+
+    private ScriptValue editor;
+
+    private UserStoreAccessControlList permissions;
+
+    public void setUserStoreKey( final String userStoreKey )
+    {
+        this.userStoreKey = UserStoreKey.from( userStoreKey );
+    }
+
+    public void setEditor( final ScriptValue editor )
+    {
+        this.editor = editor;
+    }
+
+    public void setPermissions( final ScriptValue permissions )
+    {
+        this.permissions = permissions == null
+            ? null
+            : ScriptValueToUserStoreAccessControlListTranslator.translate( permissions, this::isPrincipalExists );
+    }
+
+    public UserStoreMapper getUserStore()
+    {
+        final UserStore userStore = securityService.get().getUserStore( userStoreKey );
+        return userStore == null ? null : new UserStoreMapper( userStore );
+    }
+
+    public UserStoreMapper modifyUserStore()
+    {
+        final UserStore userStore = securityService.get().getUserStore( userStoreKey );
+
+        if ( userStore != null )
+        {
+            final UpdateUserStoreParams params = UpdateUserStoreParams.create().
+                key( userStoreKey ).
+                editor( createEditor() ).
+                permissions( permissions ).
+                build();
+
+            return new UserStoreMapper( this.securityService.get().updateUserStore( params ) );
+        }
+        return null;
+    }
+
+    private UserStoreEditor createEditor()
+    {
+        return edit -> {
+            final ScriptValue value = editor.call( new UserStoreMapper( edit.source ) );
+            if ( value != null )
+            {
+                updateUserStore( edit, value );
+            }
+        };
+    }
+
+    private void updateUserStore( final EditableUserStore target, final ScriptValue value )
+    {
+        if ( value.hasMember( "displayName" ) )
+        {
+            target.displayName = value.getMember( "displayName" ).getValue().toString();
+        }
+
+        if ( value.hasMember( "description" ) )
+        {
+            target.description = value.getMember( "description" ).getValue().toString();
+        }
+
+        if ( value.hasMember( "authConfig" ) )
+        {
+            target.authConfig = ScriptValueToAuthConfigTranslator.translate( value.getMember( "authConfig" ) );
+        }
+    }
+}

--- a/modules/app-users/src/main/java/com/enonic/xp/app/users/lib/auth/ScriptValueToUserStoreAccessControlListTranslator.java
+++ b/modules/app-users/src/main/java/com/enonic/xp/app/users/lib/auth/ScriptValueToUserStoreAccessControlListTranslator.java
@@ -1,0 +1,39 @@
+package com.enonic.xp.app.users.lib.auth;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.enonic.xp.script.ScriptValue;
+import com.enonic.xp.security.PrincipalKey;
+import com.enonic.xp.security.acl.UserStoreAccess;
+import com.enonic.xp.security.acl.UserStoreAccessControlEntry;
+import com.enonic.xp.security.acl.UserStoreAccessControlList;
+
+public final class ScriptValueToUserStoreAccessControlListTranslator
+{
+    public static UserStoreAccessControlList translate( final ScriptValue value, final Function<PrincipalKey, Boolean> isPrincipalExists )
+    {
+        final List<UserStoreAccessControlEntry> entries = value.getArray().stream().
+            map( scriptValue -> ScriptValueToUserStoreAccessControlListTranslator.mapAccessControlEntry( scriptValue, isPrincipalExists ) ).
+            filter( Objects::nonNull ).
+            collect( Collectors.toList() );
+        return UserStoreAccessControlList.create().addAll( entries ).build();
+    }
+
+    private static UserStoreAccessControlEntry mapAccessControlEntry( ScriptValue scriptValue,
+                                                                      final Function<PrincipalKey, Boolean> isPrincipalExist )
+    {
+        final String principalValue =
+            scriptValue.hasMember( "principal" ) ? scriptValue.getMember( "principal" ).getValue().toString() : null;
+        final String accessValue = scriptValue.hasMember( "access" ) ? scriptValue.getMember( "access" ).getValue().toString() : null;
+
+        final PrincipalKey principalKey = principalValue == null ? null : PrincipalKey.from( principalValue );
+        final UserStoreAccess access = UserStoreAccess.valueOf( accessValue );
+
+        final boolean hasPrincipal = principalValue != null && isPrincipalExist.apply( principalKey );
+
+        return hasPrincipal ? UserStoreAccessControlEntry.create().principal( principalKey ).access( access ).build() : null;
+    }
+}

--- a/modules/app-users/src/main/resources/assets/js/api/graphql/userStore/UpdateUserStoreRequest.ts
+++ b/modules/app-users/src/main/resources/assets/js/api/graphql/userStore/UpdateUserStoreRequest.ts
@@ -3,6 +3,7 @@ import UserStore = api.security.UserStore;
 import UserStoreKey = api.security.UserStoreKey;
 import AuthConfig = api.security.AuthConfig;
 import UserStoreJson = api.security.UserStoreJson;
+import UserStoreAccess = api.security.acl.UserStoreAccess;
 
 export class UpdateUserStoreRequest
     extends GraphQlRequest<any, UserStore> {
@@ -14,23 +15,26 @@ export class UpdateUserStoreRequest
     private permissions: api.security.acl.UserStoreAccessControlList;
 
     getVariables(): Object {
-        let authConfig = this.authConfig ? {
+        const authConfig = this.authConfig ? {
             applicationKey: this.authConfig.getApplicationKey().toString(),
-            config: this.authConfig.getConfig() ? JSON.stringify(this.authConfig.getConfig().toJson()) : undefined
-        } : undefined;
+            config: this.authConfig.getConfig() ? JSON.stringify(this.authConfig.getConfig().toJson()) : null
+        } : null;
+
+        const createAccess = p => ({principal: p.getPrincipal().getKey().toString(), access: UserStoreAccess[p.getAccess()]});
+        const permissions = this.permissions ? this.permissions.getEntries().map(createAccess) : null;
 
         let vars = super.getVariables();
         vars['key'] = this.userStoreKey.toString();
         vars['displayName'] = this.displayName;
         vars['description'] = this.description;
         vars['authConfig'] = authConfig;
-        vars['permissions'] = this.permissions ? this.permissions.toJson() : undefined;
+        vars['permissions'] = permissions;
         return vars;
     }
 
     // tslint:disable max-line-length
     getMutation(): string {
-        return `mutation ($key: String!, $displayName: String!, $description: String, $authConfig: AuthConfigInput, $permissions: [UserStoreAccessControlInput]) {
+        return `mutation ($key: String!, $displayName: String, $description: String, $authConfig: AuthConfigInput, $permissions: [UserStoreAccessControlInput]) {
             updateUserStore(key: $key, displayName: $displayName, description: $description, authConfig: $authConfig, permissions: $permissions) {
                 key
                 displayName
@@ -40,7 +44,6 @@ export class UpdateUserStoreRequest
                     config
                 }
                 idProviderMode,
-                modifiedTime,
                 permissions {
                     principal {
                         displayName

--- a/modules/app-users/src/main/resources/assets/js/app/wizard/UserStoreWizardPanel.ts
+++ b/modules/app-users/src/main/resources/assets/js/app/wizard/UserStoreWizardPanel.ts
@@ -5,7 +5,8 @@ import {UserStoreWizardPanelParams} from './UserStoreWizardPanelParams';
 import {UserStoreWizardStepForm} from './UserStoreWizardStepForm';
 import {Router} from '../Router';
 import {UserStoreWizardDataLoader} from './UserStoreWizardDataLoader';
-import UpdateUserStoreRequest = api.security.UpdateUserStoreRequest;
+import {CreateUserStoreRequest} from '../../api/graphql/userStore/CreateUserStoreRequest';
+import {UpdateUserStoreRequest} from '../../api/graphql/userStore/UpdateUserStoreRequest';
 import UserStore = api.security.UserStore;
 import UserStoreKey = api.security.UserStoreKey;
 import UserStoreBuilder = api.security.UserStoreBuilder;
@@ -13,7 +14,6 @@ import UserStoreBuilder = api.security.UserStoreBuilder;
 import WizardStep = api.app.wizard.WizardStep;
 import FormIcon = api.app.wizard.FormIcon;
 import i18n = api.util.i18n;
-import {CreateUserStoreRequest} from '../../api/graphql/userStore/CreateUserStoreRequest';
 
 export class UserStoreWizardPanel
     extends UserItemWizardPanel<UserStore> {

--- a/modules/app-users/src/main/resources/lib/auth.js
+++ b/modules/app-users/src/main/resources/lib/auth.js
@@ -65,8 +65,8 @@ exports.getPermissions = function (params) {
  * @param {string} name User store name.
  * @param {string} [params.displayName] User store display name.
  * @param {string} [params.description] User store  description.
- * @param {string} [params.authConfig] ID Provider configuration.
- * @param {string} [params.permissions] User store permissions.
+ * @param {object} [params.authConfig] ID Provider configuration.
+ * @param {object} [params.permissions] User store permissions.
  */
 exports.createUserStore = function (params) {
     var bean = __.newBean('com.enonic.xp.app.users.lib.auth.CreateUserStoreHandler');
@@ -78,4 +78,23 @@ exports.createUserStore = function (params) {
     bean.permissions = __.toScriptValue(params.permissions);
 
     return __.toNativeObject(bean.createUserStore());
+};
+
+/**
+ * Update a user store.
+ *
+ * @param {object} params JSON parameters.
+ * @param {string} params.key Key of the user store to modify.
+ * @param {function} params.editor User store editor function to apply.
+ * @param {object} [params.permissions] User store permissions.
+ * @returns {object} The updated user store.
+ */
+exports.modifyUserStore = function (params) {
+    var bean = __.newBean('com.enonic.xp.app.users.lib.auth.ModifyUserStoreHandler');
+
+    bean.userStoreKey = required(params, 'key');
+    bean.editor = __.toScriptValue(required(params, 'editor'));
+    bean.permissions = __.toScriptValue(params.permissions);
+
+    return __.toNativeObject(bean.modifyUserStore());
 };

--- a/modules/app-users/src/main/resources/lib/userstores.js
+++ b/modules/app-users/src/main/resources/lib/userstores.js
@@ -65,51 +65,18 @@ module.exports = {
     },
     update: function(params) {
         var key = common.required(params, 'key');
-        var displayName = common.required(params, 'displayName');
 
-        var updatedStore = common.update({
-            key: '/identity/' + key,
-            editor: function(store) {
-                var newStore = store;
-                newStore.displayName = displayName;
-                newStore.description = params.description;
-                newStore._permissions = calculateUserStorePermissions(
-                    params.permissions
-                );
-                newStore.idProvider = calculateIdProvider(params.authConfig);
-                return newStore;
-            }
+        return authLib.modifyUserStore({
+            key: key,
+            editor: function (userStore) {
+                var newUserStore = userStore;
+                newUserStore.displayName = params.displayName;
+                newUserStore.description = params.description;
+                newUserStore.authConfig = params.authConfig;
+                return newUserStore;
+            },
+            permissions: params.permissions
         });
-
-        var updatedUsers = common.update({
-            key: '/identity/' + key + '/users',
-            editor: function(users) {
-                var newUsers = users;
-                newUsers._permissions = calculateUsersPermissions(
-                    params.permissions
-                );
-                return newUsers;
-            }
-        });
-
-        var updatedGroups = common.update({
-            key: '/identity/' + key + '/groups',
-            editor: function(groups) {
-                var newGroups = groups;
-                newGroups._permissions = calculateGroupsPermissions(
-                    params.permissions
-                );
-                return newGroups;
-            }
-        });
-
-        updatedStore.idProviderMode = calculateIdProviderMode(
-            params.authConfig
-        );
-
-        calculateAccess(updatedStore, updatedUsers, updatedGroups);
-
-        return updatedStore;
     },
     delete: function(keys) {
         common.delete(common.keysToPaths(keys));

--- a/modules/app-users/src/main/resources/services/graphql/schema/mutation.js
+++ b/modules/app-users/src/main/resources/services/graphql/schema/mutation.js
@@ -191,7 +191,7 @@ module.exports = graphQl.createObjectType({
             type: graphQlObjectTypes.UserStoreType,
             args: {
                 key: graphQl.nonNull(graphQl.GraphQLString),
-                displayName: graphQl.nonNull(graphQl.GraphQLString),
+                displayName: graphQl.GraphQLString,
                 description: graphQl.GraphQLString,
                 authConfig: graphQlInputTypes.AuthConfigInput,
                 permissions: graphQl.list(

--- a/modules/app-users/src/main/resources/site/test/modifyUserStore-test.js
+++ b/modules/app-users/src/main/resources/site/test/modifyUserStore-test.js
@@ -1,0 +1,135 @@
+var t = require('/lib/xp/testing');
+var auth = require('/lib/auth');
+
+var expectedJson = {
+    key: 'myUserStore',
+    displayName: 'User store test',
+    description: 'User store used for testing',
+    authConfig: {
+        applicationKey: 'com.enonic.app.test',
+        config: [
+            {
+                name: 'title',
+                type: 'String',
+                values: [
+                    {
+                        v: 'App Title'
+                    }
+                ]
+            },
+            {
+                name: 'avatar',
+                type: 'Boolean',
+                values: [
+                    {
+                        v: true
+                    }
+                ]
+            },
+            {
+                name: 'forgotPassword',
+                type: 'PropertySet',
+                values: [
+                    {
+                        set: [
+                            {
+                                name: 'email',
+                                type: 'String',
+                                values: [
+                                    {
+                                        v: 'noreply@example.com'
+                                    }
+                                ]
+                            },
+                            {
+                                name: 'site',
+                                type: 'String',
+                                values: [
+                                    {
+                                        v: 'MyWebsite'
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+};
+
+exports.modifyUserStore = function () {
+    var result = auth.modifyUserStore({
+        key: 'myUserStore',
+        editor: function (userStore) {
+            var newUserStore = userStore;
+            newUserStore.displayName = 'User store test';
+            newUserStore.description = 'User store used for testing';
+            newUserStore.authConfig = {
+                applicationKey: 'com.enonic.app.test',
+                config: [
+                    {
+                        name: 'title',
+                        type: 'String',
+                        values: [
+                            {
+                                v: 'App Title'
+                            }
+                        ]
+                    },
+                    {
+                        name: 'avatar',
+                        type: 'Boolean',
+                        values: [
+                            {
+                                v: true
+                            }
+                        ]
+                    },
+                    {
+                        name: 'forgotPassword',
+                        type: 'PropertySet',
+                        values: [
+                            {
+                                set: [
+                                    {
+                                        name: 'email',
+                                        type: 'String',
+                                        values: [
+                                            {
+                                                v: 'noreply@example.com'
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        name: 'site',
+                                        type: 'String',
+                                        values: [
+                                            {
+                                                v: 'MyWebsite'
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            };
+            return newUserStore
+        },
+        permissions: [
+            {
+                principal: 'user:myUserStore:user',
+                access: 'ADMINISTRATOR'
+            },
+            {
+                principal: 'group:myUserStore:group',
+                access: 'CREATE_USERS'
+            }
+        ]
+    });
+
+    t.assertJsonEquals(expectedJson, result);
+};
+

--- a/modules/app-users/src/test/java/com/enonic/xp/app/users/lib/auth/ModifyUserStoreHandlerTest.java
+++ b/modules/app-users/src/test/java/com/enonic/xp/app/users/lib/auth/ModifyUserStoreHandlerTest.java
@@ -1,0 +1,65 @@
+package com.enonic.xp.app.users.lib.auth;
+
+import java.util.Optional;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.enonic.xp.security.EditableUserStore;
+import com.enonic.xp.security.PrincipalKey;
+import com.enonic.xp.security.SecurityService;
+import com.enonic.xp.security.UpdateUserStoreParams;
+import com.enonic.xp.security.UserStore;
+import com.enonic.xp.security.UserStoreEditor;
+import com.enonic.xp.security.acl.UserStoreAccess;
+import com.enonic.xp.security.acl.UserStoreAccessControlEntry;
+import com.enonic.xp.security.acl.UserStoreAccessControlList;
+import com.enonic.xp.testing.ScriptTestSupport;
+
+import static org.junit.Assert.*;
+
+public class ModifyUserStoreHandlerTest
+    extends ScriptTestSupport
+{
+    private SecurityService securityService;
+
+    @Override
+    public void initialize()
+        throws Exception
+    {
+        super.initialize();
+        this.securityService = Mockito.mock( SecurityService.class );
+        addService( SecurityService.class, this.securityService );
+    }
+
+    @Test
+    public void testModifyUserStore()
+    {
+        Mockito.when( securityService.getUserStore( Mockito.any() ) ).thenReturn( TestDataFixtures.getTestBlankUserStore() );
+        Mockito.when( securityService.getPrincipal( Mockito.any() ) ).thenReturn( Optional.empty() ).thenReturn(
+            (Optional) Optional.of( TestDataFixtures.getTestGroup() ) );
+        Mockito.when( securityService.updateUserStore( Mockito.isA( UpdateUserStoreParams.class ) ) ).thenAnswer(
+            invocationOnMock -> invokeUpdate( (UpdateUserStoreParams) invocationOnMock.getArguments()[0] ) );
+
+        runFunction( "/site/test/modifyUserStore-test.js", "modifyUserStore" );
+    }
+
+    private UserStore invokeUpdate( final UpdateUserStoreParams params )
+    {
+        final UserStoreEditor editor = params.getEditor();
+        Assert.assertNotNull( editor );
+
+        final UserStoreAccessControlList permissions = params.getUserStorePermissions();
+        Assert.assertNotNull( "Permissions should not be empty", permissions );
+        final UserStoreAccessControlEntry entry = permissions.getEntry( PrincipalKey.from( "group:myUserStore:group" ) );
+        assertNotNull( entry );
+        assertEquals( entry.getAccess(), UserStoreAccess.CREATE_USERS );
+        assertEquals( params.getUserStorePermissions().getAllPrincipals().getSize(), 1 );
+
+        final EditableUserStore editable = new EditableUserStore( TestDataFixtures.getTestBlankUserStore() );
+
+        editor.edit( editable );
+        return editable.build();
+    }
+}

--- a/modules/app-users/src/test/java/com/enonic/xp/app/users/lib/auth/TestDataFixtures.java
+++ b/modules/app-users/src/test/java/com/enonic/xp/app/users/lib/auth/TestDataFixtures.java
@@ -55,13 +55,21 @@ public class TestDataFixtures
             build();
     }
 
+    public static UserStore getTestBlankUserStore()
+    {
+        return UserStore.create().
+            key( UserStoreKey.from( "myUserStore" ) ).
+            displayName( "" ).
+            description( "" ).
+            build();
+    }
 
     public static UserStore getTestUserStore()
     {
         return UserStore.create().
             key( UserStoreKey.from( "myUserStore" ) ).
-            description( "User store used for testing" ).
             displayName( "User store test" ).
+            description( "User store used for testing" ).
             authConfig( getTestAuthConfig() ).
             build();
     }


### PR DESCRIPTION
* Added `modifyUserStore` `auth.js` function, that supports `key`, `editor` (function) and `permissions` parameters.
* `modifyUserStore` function is called `modify*`, instead of `update*`, because all similar function for principals is called that way.
* Permissions parameter is not a part of the `editor` since user store doesn't contain permissions field.
* Permissions parameter is part of the `modifyUserStore` since it will be used only with that action.
* Updated UserStore handlers, by moving shared code to the abstract class.
* Moved `UserStoreAccessControlList` parsing from `ScriptValue` to the `*Translator` class.