### PR TITLE
Implement flags for building lib-admin-ui in dev and prod modes as a part of composite build #540

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,75 @@
-# Enonic XP Apps
+Enonic XP Apps
+===
 
-This repository holds all bundled Enonic XP applications.
+[![Travis Build Status][travis-image]][travis-url]
+[![License][license-image]][license-url]
+
+Core applications for [Enonic XP](https://github.com/enonic/xp).
+
+## Usage
+
+Just copy the built JAR files to the `$XP_HOME/deploy` folder, or use the `deploy` task from the Gradle:
+
+```
+./gradlew deploy
+```
+
+## Building
+
+#### Default
+
+Run the following command to build all applications with default options:
+
+```
+./gradlew build
+```
+
+With default build, applications will use the remote `lib-admin-ui` dependency and the environment variable won't be set.
+
+#### Environment
+
+To use the specific environment, you must set its value explicitly with `env` parameter (only `prod` or `dev`):
+
+```
+./gradlew build -Penv=dev
+```
+
+If the environment is set, the Gradle will look for the local `lib-admin-ui` and `xp` repositories in the parent folder of your `xp-apps` repo. And if any present, will build them, along with building applications, instead of downloading the remote `lib-admin-ui` dependency.
+The environment parameter will also be passed to `lib-admin-ui`.
+
+Both environments are almost identical, except that building in the development environment will result in creating the DTS files, sourcemaps and other things, critical for the debugging.
+The build itself may also be a bit slower sometimes. 
+
+#### Quick
+
+Sometimes, you may want to build your project faster. To do so, just skip the linting (`lint` task) and testing (`test` task):
+
+```
+./gradlew build -x lint -x test
+```
+
+In cases, when you set the environment type explicitly, skipping the `lint` or `test` will also result in skipping those two tasks in local `lib-admin-ui` build.
+
+#### Clean
+
+To rebuild the project from scratch, you may want to remove all compiles sources and dependencies. In that case, using `clean` command may not be enough. To remove the build and dependencies, use:
+
+```
+./gradlew flush
+```
+
+#### NPM upgrade
+
+In case you want forcefully update all your node dependencies, use:
+
+```
+./gradlew npmInstallForce
+```
+
+Take a note, that you can also use aliases in Gradle, and `nIF` would be just enough to run `npmInstallForce`.
+
+<!-- Links -->
+[travis-url]:    https://travis-ci.org/enonic/xp-apps
+[travis-image]:  https://travis-ci.org/enonic/xp-apps.svg?branch=master "Build status"
+[license-url]:   LICENSE.txt
+[license-image]: https://img.shields.io/github/license/enonic/lib-admin-ui.svg "GPL 3.0"

--- a/build.gradle
+++ b/build.gradle
@@ -5,14 +5,49 @@ plugins {
 allprojects {
     apply plugin: 'com.moowork.node'
     group = 'com.enonic.xp'
+
+    task flush( type: Delete ) {
+        description = 'Clean the project from built sources and dependencies'
+        delete '.xp'
+    }
+
+    task npmInstallForce( type: NpmTask ) {
+        description = 'Update all project node dependencies'
+        args = ['install', '--force']
+    }
 }
 
 subprojects {
     apply plugin: 'java'
+
+    flush.dependsOn += clean
 }
 
-task build {
-    if (project.hasProperty('all')) {
-        dependsOn gradle.includedBuild( 'lib-admin-ui' ).task( ':buildNoLint' )
+if ( hasProperty( 'env' ) )
+{
+    addBuildDependency()
+    applyExcludedTasks()
+}
+
+def applyExcludedTasks() {
+    def libAdminUi = gradle.includedBuild( 'lib-admin-ui' )
+    Closure permittedTasks = { it == 'lint' || it == 'test' }
+    def excludedTasks = gradle.startParameter.getExcludedTaskNames().findAll( permittedTasks )
+    libAdminUi.getLoadedSettings().getStartParameter().setExcludedTaskNames( excludedTasks )
+}
+
+def addBuildDependency() {
+    def buildTask = gradle.includedBuild( 'lib-admin-ui' ).task( ':build' )
+
+    task build {
+        dependsOn buildTask
+    }
+
+    subprojects.each {
+        def webpackTask = tasks.findByPath( ":${it.name}:webpack" )
+        def unpackDevResources = tasks.findByPath( ":${it.name}:unpackDevResources" )
+
+        if ( webpackTask != null ) webpackTask.dependsOn += unpackDevResources
+        unpackDevResources.dependsOn += buildTask
     }
 }

--- a/gradle/defaults.gradle
+++ b/gradle/defaults.gradle
@@ -1,4 +1,3 @@
-
 // Add more dev source paths for development
 app {
     devSourcePaths += file("$rootDir/../lib-admin-ui/src/main/resources")

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,8 +2,7 @@ include ':app-applications'
 include ':app-contentstudio'
 include ':app-users'
 
-
-if (startParameter.getProjectProperties().containsKey('all')) {
+if ( hasProperty( 'env' ) ) {
     addBuild('../xp')
     addBuild('../lib-admin-ui')
 }


### PR DESCRIPTION
* Added support of the `env` parameter with value: `prod` or `dev`: `-Pall=dev`.
* Added copying the excluded task to `lib-admin-ui`, so it is now possible to skip lint (or test) in both `xp-apps` and `lib-admin-ui` with just passing `-x lint` from CLI.
* Fixed the build order: `xp-apps` won't call `unpackDevResources` until the `lib-admin-ui` fully built. There is no need to call the `lib-admin-ui` build manually now.
* Added Gradle `flush` command to remove all built data.
* Added Gradle `npmInstallForce` to forcefully install and update all node dependencies.
* Updated documentation.