### PR TITLE
Grid Context Menu - 'Undo delete' menu item should not be displayed, …

### DIFF
--- a/modules/app-contentstudio/src/main/resources/assets/js/app/browse/action/UndoPendingDeleteContentAction.ts
+++ b/modules/app-contentstudio/src/main/resources/assets/js/app/browse/action/UndoPendingDeleteContentAction.ts
@@ -11,7 +11,6 @@ export class UndoPendingDeleteContentAction extends Action {
         super(i18n('action.undoDelete'));
 
         this.setEnabled(true);
-        this.setVisible(false);
 
         this.onExecuted(() => {
             let contents: api.content.ContentSummaryAndCompareStatus[]


### PR DESCRIPTION
…when the state of content is not 'Deleted' #575