### PR TITLE
Principal Browse Filter Panel - Group- aggregation does not appear on…

### DIFF
--- a/modules/app-users/src/main/resources/assets/js/app/browse/UserBrowsePanel.ts
+++ b/modules/app-users/src/main/resources/assets/js/app/browse/UserBrowsePanel.ts
@@ -70,6 +70,14 @@ export class UserBrowsePanel
         serverHandler.onUserItemCreated((principal: Principal, userStore: UserStore, sameTypeParent?: boolean) => {
             this.treeGrid.appendUserNode(principal, userStore, sameTypeParent);
             this.setRefreshOfFilterRequired();
+
+            /*
+                In case you switch to UserBrowsePanel before this event occured you need to trigger refresh manually
+                Otherwise 'shown' event won't update filter
+             */
+            if (this.isVisible()) {
+                this.refreshFilter();
+            }
         });
 
         serverHandler.onUserItemUpdated((principal: Principal, userStore: UserStore) => {


### PR DESCRIPTION
… the filter panel, when a group has been added #650

-Issue was that filter panel is updated on shown event; In case when you create user item and immediately switch to UserBrowsePanel -> filter panel is shown before server event received ,thus no update triggered.