### PR TITLE
 Insights User Store wizard - Confirmation about unsaved changes when…

### DIFF
--- a/modules/app-users/src/main/resources/assets/js/app/wizard/UserStoreWizardPanel.ts
+++ b/modules/app-users/src/main/resources/assets/js/app/wizard/UserStoreWizardPanel.ts
@@ -245,7 +245,7 @@ export class UserStoreWizardPanel
         const authConfig = this.userStoreWizardStepForm.getAuthConfig();
         return wizardHeader.getName() !== '' ||
                wizardHeader.getDisplayName() !== '' ||
-               this.userStoreWizardStepForm.getDescription() !== this.defaultUserStore.getDescription() ||
+               !api.ObjectHelper.stringEquals(this.userStoreWizardStepForm.getDescription(), this.defaultUserStore.getDescription()) ||
                !(!authConfig || authConfig.equals(this.defaultUserStore.getAuthConfig())) ||
                !this.permissionsWizardStepForm.getPermissions().equals(this.defaultUserStore.getPermissions());
     }


### PR DESCRIPTION
… no changes were made #689

Fixed the description check, since both strings may contain `null` or `undefined`, which should be equal.