### PR TITLE
Users App - error appears in browser console, when delete a role #697

### DIFF
--- a/modules/app-users/src/main/resources/assets/js/app/browse/UserItemsTreeGrid.ts
+++ b/modules/app-users/src/main/resources/assets/js/app/browse/UserItemsTreeGrid.ts
@@ -112,6 +112,10 @@ export class UserItemsTreeGrid
     }
 
     updateUserNode(principal: api.security.Principal, userStore: api.security.UserStore) {
+        if (!principal && !userStore) {
+            return;
+        }
+
         let userTreeGridItem;
         let builder = new UserTreeGridItemBuilder();
 


### PR DESCRIPTION
Added `if` handler, when both Principal and UserStore are null and updated node no longer exists.