### PR TITLE
In Page Editor common CSS styles from XP override custom styles used …

### DIFF
--- a/modules/app-contentstudio/src/main/java/com/enonic/xp/app/contentstudio/LiveEditInjection.java
+++ b/modules/app-contentstudio/src/main/java/com/enonic/xp/app/contentstudio/LiveEditInjection.java
@@ -27,13 +27,13 @@ public final class LiveEditInjection
 {
     private LocaleService localeService;
 
-    private final StringTemplate headEndTemplate;
+    private final StringTemplate headBeginTemplate;
 
     private final StringTemplate bodyEndTemplate;
 
     public LiveEditInjection()
     {
-        this.headEndTemplate = StringTemplate.load( getClass(), "liveEditHeadEnd.html" );
+        this.headBeginTemplate = StringTemplate.load( getClass(), "liveEditHeadBegin.html" );
         this.bodyEndTemplate = StringTemplate.load( getClass(), "liveEditBodyEnd.html" );
     }
 
@@ -45,9 +45,9 @@ public final class LiveEditInjection
             return null;
         }
 
-        if ( htmlTag == HtmlTag.HEAD_END )
+        if ( htmlTag == HtmlTag.HEAD_BEGIN )
         {
-            return Collections.singletonList( injectHeadEnd( portalRequest ) );
+            return Collections.singletonList( injectHeadBegin( portalRequest ) );
         }
 
         if ( htmlTag == HtmlTag.BODY_END )
@@ -58,9 +58,9 @@ public final class LiveEditInjection
         return null;
     }
 
-    private String injectHeadEnd( final PortalRequest portalRequest )
+    private String injectHeadBegin( final PortalRequest portalRequest )
     {
-        return injectUsingTemplate( this.headEndTemplate, makeModelForHeadEnd( portalRequest ) );
+        return injectUsingTemplate( this.headBeginTemplate, makeModelForHeadBegin( portalRequest ) );
     }
 
     private String injectBodyEnd( final PortalRequest portalRequest )
@@ -73,7 +73,7 @@ public final class LiveEditInjection
         return template.apply( model ).trim() + "\n";
     }
 
-    private Map<String, String> makeModelForHeadEnd( final PortalRequest portalRequest )
+    private Map<String, String> makeModelForHeadBegin( final PortalRequest portalRequest )
     {
         final Map<String, String> map = Maps.newHashMap();
         map.put( "assetsUrl", portalRequest.rewriteUri( "/admin/_/asset/com.enonic.xp.app.contentstudio" ) );
@@ -82,7 +82,7 @@ public final class LiveEditInjection
 
     private Map<String, String> makeModelForBodyEnd( final PortalRequest portalRequest )
     {
-        final Map<String, String> map = makeModelForHeadEnd( portalRequest );
+        final Map<String, String> map = makeModelForHeadBegin( portalRequest );
 
         final MessageBundle bundle =
             this.localeService.getBundle( ApplicationKey.from( "com.enonic.xp.app.contentstudio" ), resolveLocale( portalRequest ),

--- a/modules/app-contentstudio/src/main/resources/assets/page-editor/styles/reset.less
+++ b/modules/app-contentstudio/src/main/resources/assets/page-editor/styles/reset.less
@@ -10,9 +10,6 @@ html {
     // for crosshair highlighter to be drawn properly when content is shorter than window
     min-height: 100%;
     margin: 0;
-    // Reset the default body font of the lib-admin-ui css
-    font-family: unset;
-    font-size: initial;
 
     svg:not(:root) {
       overflow: visible;
@@ -31,4 +28,10 @@ html {
       }
     }
   }
+}
+
+body {
+  // Reset the default body font of the lib-admin-ui css
+  font-family: unset;
+  font-size: initial;
 }

--- a/modules/app-contentstudio/src/main/resources/com/enonic/xp/app/contentstudio/liveEditHeadBegin.html
+++ b/modules/app-contentstudio/src/main/resources/com/enonic/xp/app/contentstudio/liveEditHeadBegin.html
@@ -1,3 +1,4 @@
-<!-- Live edit injection -->
+<!-- Live edit injection BEGIN -->
 <link rel="stylesheet" type="text/css" href="{{assetsUrl}}/admin/common/styles/_all.css">
 <link id="live-edit-css" rel="stylesheet" type="text/css" href="{{assetsUrl}}/page-editor/styles/_all.css"/>
+<!-- Live edit injection END -->

--- a/modules/app-contentstudio/src/test/java/com/enonic/xp/app/contentstudio/LiveEditInjectionTest.java
+++ b/modules/app-contentstudio/src/test/java/com/enonic/xp/app/contentstudio/LiveEditInjectionTest.java
@@ -52,7 +52,7 @@ public class LiveEditInjectionTest
     {
         this.portalRequest.setMode( RenderMode.EDIT );
 
-        final List<String> result1 = this.injection.inject( this.portalRequest, this.portalResponse, HtmlTag.HEAD_BEGIN );
+        final List<String> result1 = this.injection.inject( this.portalRequest, this.portalResponse, HtmlTag.HEAD_END );
         assertNull( result1 );
 
         final List<String> result2 = this.injection.inject( this.portalRequest, this.portalResponse, HtmlTag.BODY_BEGIN );
@@ -65,17 +65,17 @@ public class LiveEditInjectionTest
     }
 
     @Test
-    public void testInjectHeadEnd()
+    public void testInjectHeadBegin()
         throws Exception
     {
         this.portalRequest.setMode( RenderMode.EDIT );
 
-        final List<String> list = this.injection.inject( this.portalRequest, this.portalResponse, HtmlTag.HEAD_END );
+        final List<String> list = this.injection.inject( this.portalRequest, this.portalResponse, HtmlTag.HEAD_BEGIN );
         assertNotNull( list );
 
         final String result = list.get( 0 );
         assertNotNull( result );
-        assertEquals( readResource( "liveEditInjectionHeadEnd.html" ).trim() + "\n", result );
+        assertEquals( readResource( "liveEditInjectionHeadBegin.html" ).trim() + "\n", result );
     }
 
     @Test

--- a/modules/app-contentstudio/src/test/resources/com/enonic/xp/app/contentstudio/liveEditInjectionHeadBegin.html
+++ b/modules/app-contentstudio/src/test/resources/com/enonic/xp/app/contentstudio/liveEditInjectionHeadBegin.html
@@ -1,3 +1,4 @@
-<!-- Live edit injection -->
+<!-- Live edit injection BEGIN -->
 <link rel="stylesheet" type="text/css" href="/admin/_/asset/com.enonic.xp.app.contentstudio/admin/common/styles/_all.css">
 <link id="live-edit-css" rel="stylesheet" type="text/css" href="/admin/_/asset/com.enonic.xp.app.contentstudio/page-editor/styles/_all.css"/>
+<!-- Live edit injection END -->


### PR DESCRIPTION
…on the page #744

Updated the reset file, to reset `body` styles less strictly.
Updated the order of the tags injection to the `head` in live edit, to prevent common tags style override.